### PR TITLE
Handle when ignoring passkey already exists error on signup

### DIFF
--- a/android/src/main/java/com/authsignal/react/AuthsignalPasskeyModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalPasskeyModule.kt
@@ -48,10 +48,13 @@ class AuthsignalPasskeyModule(private val reactContext: ReactApplicationContext)
         val errorCode = response.errorCode ?: defaultError
 
         promise.reject(errorCode, response.error)
-      } else {
+      } else if (response.data != null) {
         val signUpResponse = response.data
         val map = Arguments.createMap()
         map.putString("token", signUpResponse!!.token)
+        promise.resolve(map)
+      } else {
+        val map = Arguments.createMap()
         promise.resolve(map)
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-authsignal",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "The official Authsignal React Native library.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
### Bug Fixes
- Handle when ignoring passkey already exists error on signup

### Checklist
- [ ] Version bumped