### PR TITLE
fix quit button not responsive on ios

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,5 +61,5 @@ dependencies {
 
   implementation "androidx.browser:browser:1.2.0"
 
-  implementation("com.authsignal:authsignal-android:3.6.0")
+  implementation("com.authsignal:authsignal-android:3.7.0")
 }

--- a/android/src/main/java/com/authsignal/react/AuthsignalModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalModule.kt
@@ -44,7 +44,7 @@ class AuthsignalModule(private val reactContext: ReactApplicationContext) :
     }
 
     val activity = reactContext.currentActivity
-    val parsedUrl = Uri.parse(url)
+    val parsedUrl = buildLaunchUri(url)
     this.launchPromise = promise
 
     try {
@@ -110,7 +110,26 @@ class AuthsignalModule(private val reactContext: ReactApplicationContext) :
   override fun onNewIntent(intent: Intent) {
   }
 
+  private fun buildLaunchUri(url: String): Uri {
+    val parsedUrl = Uri.parse(url)
+    val builder = parsedUrl.buildUpon().clearQuery()
+
+    for (queryName in parsedUrl.queryParameterNames) {
+      if (queryName == NATIVE_SCHEME_QUERY_PARAM) continue
+
+      for (queryValue in parsedUrl.getQueryParameters(queryName)) {
+        builder.appendQueryParameter(queryName, queryValue)
+      }
+    }
+
+    builder.appendQueryParameter(NATIVE_SCHEME_QUERY_PARAM, CALLBACK_SCHEME)
+
+    return builder.build()
+  }
+
   companion object {
     const val NAME = "AuthsignalModule"
+    private const val CALLBACK_SCHEME = "authsignal"
+    private const val NATIVE_SCHEME_QUERY_PARAM = "nativeScheme"
   }
 }

--- a/ios/AuthsignalModule.swift
+++ b/ios/AuthsignalModule.swift
@@ -6,6 +6,8 @@ import Security
 
 @objc(AuthsignalModule)
 class AuthsignalModule: NSObject, ASWebAuthenticationPresentationContextProviding {
+  private let callbackScheme = "authsignal"
+  private let nativeSchemeQueryItemName = "nativeScheme"
   var session: ASWebAuthenticationSession?
   
   @objc static func requiresMainQueueSetup() -> Bool {
@@ -21,15 +23,13 @@ class AuthsignalModule: NSObject, ASWebAuthenticationPresentationContextProvidin
     resolve: @escaping RCTPromiseResolveBlock,
     reject: @escaping RCTPromiseRejectBlock
   ) -> Void {
-    let scheme = "authsignal"
-
-    guard let authUrl = URL(string: url as String) else {
+    guard let authUrl = buildLaunchURL(from: url as String) else {
       reject("launchError", "Invalid URL", nil)
       
       return
     }
     
-    let authenticationSession = ASWebAuthenticationSession(url: authUrl, callbackURLScheme: scheme) { callbackURL, error in
+    let authenticationSession = ASWebAuthenticationSession(url: authUrl, callbackURLScheme: callbackScheme) { callbackURL, error in
       if let error {
         if self.isCanceledLoginError(error) {
           resolve(nil)
@@ -88,6 +88,19 @@ class AuthsignalModule: NSObject, ASWebAuthenticationPresentationContextProvidin
   
   private func isCanceledLoginError(_ error: Error) -> Bool {
     (error as NSError).code == ASWebAuthenticationSessionError.canceledLogin.rawValue
+  }
+
+  private func buildLaunchURL(from urlString: String) -> URL? {
+    guard let authUrl = URL(string: urlString),
+      var components = URLComponents(url: authUrl, resolvingAgainstBaseURL: false) else {
+      return nil
+    }
+
+    var queryItems = components.queryItems?.filter { $0.name != nativeSchemeQueryItemName } ?? []
+    queryItems.append(URLQueryItem(name: nativeSchemeQueryItemName, value: callbackScheme))
+    components.queryItems = queryItems
+
+    return components.url
   }
   
   func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-authsignal",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "The official Authsignal React Native library.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-authsignal.podspec
+++ b/react-native-authsignal.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.private_header_files = "ios/**/*.h"
 
   s.dependency "React-Core"
-  s.dependency 'Authsignal', '2.5.0'
+  s.dependency 'Authsignal', '2.6.0'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION

### Bug Fixes
  - iOS: the Quit button on the prebuilt MFA page was unresponsive when the caller passed an HTTPS `redirectUrl` to `track`. The SDK now appends`nativeScheme=authsignal` to the launch URL so the prebuilt UI's exit redirect matches `ASWebAuthenticationSession`'s callback scheme. 

### Checklist
- [x] Version bumped