### PR TITLE
bump native sdk versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,5 +61,5 @@ dependencies {
 
   implementation "androidx.browser:browser:1.2.0"
 
-  implementation("com.authsignal:authsignal-android:3.7.0")
+  implementation("com.authsignal:authsignal-android:3.8.0")
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-authsignal",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "The official Authsignal React Native library.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-authsignal.podspec
+++ b/react-native-authsignal.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.private_header_files = "ios/**/*.h"
 
   s.dependency "React-Core"
-  s.dependency 'Authsignal', '2.6.0'
+  s.dependency 'Authsignal', '2.7.0'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
## Summary
- Bumps iOS Authsignal pod to 2.7.0 and Android authsignal-android to 3.8.0
- Picks up nonce-based attestation in the underlying native SDKs
