### PR TITLE
feat: accept optional pushToken on push enrollment

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,5 +61,5 @@ dependencies {
 
   implementation "androidx.browser:browser:1.2.0"
 
-  implementation("com.authsignal:authsignal-android:3.8.0")
+  implementation("com.authsignal:authsignal-android:3.9.0")
 }

--- a/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
@@ -55,10 +55,16 @@ class AuthsignalPushModule(private val reactContext: ReactApplicationContext) :
     _requireUserAuthentication: Boolean,
     _keychainAccess: String?,
     performAttestation: Boolean,
+    pushToken: String?,
     promise: Promise
   ) {
     launch(promise) {
-      val response = it.addCredential(token, null, performAttestation = performAttestation)
+      val response = it.addCredential(
+        token,
+        null,
+        performAttestation = performAttestation,
+        pushToken = pushToken,
+      )
 
       if (response.error != null) {
         val errorCode = response.errorCode ?: defaultError

--- a/ios/AuthsignalPushModule.m
+++ b/ios/AuthsignalPushModule.m
@@ -15,6 +15,7 @@ RCT_EXTERN_METHOD(addCredential:(NSString)token
                   withRequireUserAuthentication:(BOOL)requireUserAuthentication
                   withKeychainAccess:(NSString)keychainAccess
                   withPerformAttestation:(BOOL)performAttestation
+                  withPushToken:(NSString)pushToken
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 

--- a/ios/AuthsignalPushModule.swift
+++ b/ios/AuthsignalPushModule.swift
@@ -56,6 +56,7 @@ class AuthsignalPushModule: NSObject {
     withRequireUserAuthentication requireUserAuthentication: Bool,
     withKeychainAccess keychainAccess: NSString?,
     withPerformAttestation performAttestation: Bool,
+    withPushToken pushToken: NSString?,
     resolve: @escaping RCTPromiseResolveBlock,
     reject: @escaping RCTPromiseRejectBlock
   ) -> Void {
@@ -67,13 +68,15 @@ class AuthsignalPushModule: NSObject {
     let tokenStr = token as String?
     let requireAuthentication = requireUserAuthentication as Bool
     let keychainAccess = getKeychainAccess(value: keychainAccess as String?)
+    let pushTokenStr = pushToken as String?
 
     Task.init {
       let response = await authsignal.addCredential(
         token: tokenStr,
         keychainAccess: keychainAccess,
         userPresenceRequired: requireAuthentication,
-        performAttestation: performAttestation
+        performAttestation: performAttestation,
+        pushToken: pushTokenStr
       )
       
       if let error = response.error {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-authsignal",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "The official Authsignal React Native library.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-authsignal.podspec
+++ b/react-native-authsignal.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.private_header_files = "ios/**/*.h"
 
   s.dependency "React-Core"
-  s.dependency 'Authsignal', '2.7.0'
+  s.dependency 'Authsignal', '2.8.0'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/src/NativeAuthsignalPushModule.ts
+++ b/src/NativeAuthsignalPushModule.ts
@@ -7,7 +7,8 @@ export interface Spec extends TurboModule {
     token: string | null,
     withRequireUserAuthentication: boolean,
     withKeychainAccess: string | null,
-    withPerformAttestation: boolean
+    withPerformAttestation: boolean,
+    withPushToken: string | null
   ): Promise<Object | null>;
   removeCredential(): Promise<boolean>;
   getChallenge(): Promise<Object | null>;

--- a/src/push.ts
+++ b/src/push.ts
@@ -59,6 +59,7 @@ export class AuthsignalPush {
     requireUserAuthentication = false,
     keychainAccess,
     performAttestation,
+    pushToken,
   }: AddCredentialInput = {}): Promise<AuthsignalResponse<AppCredential>> {
     await this.ensureModuleIsInitialized();
 
@@ -67,7 +68,8 @@ export class AuthsignalPush {
         token ?? null,
         requireUserAuthentication,
         keychainAccess ?? null,
-        performAttestation ?? false
+        performAttestation ?? false,
+        pushToken ?? null
       )) as AppCredential;
 
       return { data };

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,14 +50,6 @@ export interface AddCredentialInput {
   requireUserAuthentication?: boolean;
   keychainAccess?: KeychainAccess;
   performAttestation?: boolean;
-  /**
-   * Optional push provider token (e.g. FCM/APNs registration token) to
-   * associate with the enrolled push authenticator. When supplied, the
-   * Authsignal backend stores the token on the user authenticator and uses
-   * it later to deliver push challenges. The host app is responsible for
-   * sourcing this token from its push stack of choice (FCM, APNs, Airship,
-   * etc.) - this SDK stays push-stack-agnostic.
-   */
   pushToken?: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,15 @@ export interface AddCredentialInput {
   requireUserAuthentication?: boolean;
   keychainAccess?: KeychainAccess;
   performAttestation?: boolean;
+  /**
+   * Optional push provider token (e.g. FCM/APNs registration token) to
+   * associate with the enrolled push authenticator. When supplied, the
+   * Authsignal backend stores the token on the user authenticator and uses
+   * it later to deliver push challenges. The host app is responsible for
+   * sourcing this token from its push stack of choice (FCM, APNs, Airship,
+   * etc.) - this SDK stays push-stack-agnostic.
+   */
+  pushToken?: string;
 }
 
 export interface AppChallenge {


### PR DESCRIPTION
## Summary

Adds an optional `pushToken?: string` to the `addCredential` input on `authsignal.push.addCredential(...)`. The value is forwarded through the native module bridge to the iOS and Android SDKs, which in turn send it on the `POST /v1/client/user-authenticators/push` request body.

