### PR TITLE
Add wrapper request metadata

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,10 @@
+import groovy.json.JsonSlurper
+
 apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'com.facebook.react'
+
+def packageJson = new JsonSlurper().parseText(file("../package.json").text)
 
 def getExtOrDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties['Authsignal_' + name]
@@ -24,6 +28,7 @@ android {
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
+    buildConfigField "String", "VERSION_NAME", "\"${packageJson.version}\""
   }
 
   buildTypes {
@@ -61,5 +66,5 @@ dependencies {
 
   implementation "androidx.browser:browser:1.2.0"
 
-  implementation("com.authsignal:authsignal-android:3.9.0")
+  implementation("com.authsignal:authsignal-android:3.9.1")
 }

--- a/android/src/main/java/com/authsignal/react/AuthsignalEmailModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalEmailModule.kt
@@ -26,6 +26,7 @@ class AuthsignalEmailModule(private val reactContext: ReactApplicationContext) :
     val currentActivity = reactContext.currentActivity
 
     if (currentActivity != null) {
+      RequestMetadata.configure()
       authsignal = AuthsignalEmail(tenantID, baseURL)
     }
 

--- a/android/src/main/java/com/authsignal/react/AuthsignalInAppModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalInAppModule.kt
@@ -21,6 +21,7 @@ class AuthsignalInAppModule(private val reactContext: ReactApplicationContext) :
 
   @ReactMethod
   override fun initialize(tenantID: String, baseURL: String, promise: Promise) {
+    RequestMetadata.configure()
     authsignal = AuthsignalInApp(tenantID, baseURL, context = reactContext)
 
     promise.resolve(null)

--- a/android/src/main/java/com/authsignal/react/AuthsignalPasskeyModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalPasskeyModule.kt
@@ -24,6 +24,7 @@ class AuthsignalPasskeyModule(private val reactContext: ReactApplicationContext)
     val activity = reactContext.currentActivity
 
     if (activity != null) {
+      RequestMetadata.configure()
       authsignal = AuthsignalPasskey(tenantID, baseURL, activity, deviceID)
     }
 

--- a/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
@@ -21,6 +21,7 @@ class AuthsignalPushModule(private val reactContext: ReactApplicationContext) :
 
   @ReactMethod
   override fun initialize(tenantID: String, baseURL: String, promise: Promise) {
+    RequestMetadata.configure()
     authsignal = AuthsignalPush(tenantID, baseURL)
 
     promise.resolve(null)

--- a/android/src/main/java/com/authsignal/react/AuthsignalQRCodeModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalQRCodeModule.kt
@@ -21,6 +21,7 @@ class AuthsignalQRCodeModule(private val reactContext: ReactApplicationContext) 
 
   @ReactMethod
   override fun initialize(tenantID: String, baseURL: String, promise: Promise) {
+    RequestMetadata.configure()
     authsignal = AuthsignalQRCode(tenantID, baseURL)
 
     promise.resolve(null)

--- a/android/src/main/java/com/authsignal/react/AuthsignalSMSModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalSMSModule.kt
@@ -23,6 +23,7 @@ class AuthsignalSMSModule(private val reactContext: ReactApplicationContext) :
     val currentActivity = reactContext.currentActivity
 
     if (currentActivity != null) {
+      RequestMetadata.configure()
       authsignal = AuthsignalSMS(tenantID, baseURL)
     }
 

--- a/android/src/main/java/com/authsignal/react/AuthsignalTOTPModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalTOTPModule.kt
@@ -24,6 +24,7 @@ class AuthsignalTOTPModule(private val reactContext: ReactApplicationContext) :
     val currentActivity = reactContext.currentActivity
 
     if (currentActivity != null) {
+      RequestMetadata.configure()
       authsignal = AuthsignalTOTP(tenantID, baseURL)
     }
 

--- a/android/src/main/java/com/authsignal/react/AuthsignalWhatsappModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalWhatsappModule.kt
@@ -23,6 +23,7 @@ class AuthsignalWhatsappModule(private val reactContext: ReactApplicationContext
     val currentActivity = reactContext.currentActivity
 
     if (currentActivity != null) {
+      RequestMetadata.configure()
       authsignal = AuthsignalWhatsApp(tenantID, baseURL)
     }
 

--- a/android/src/main/java/com/authsignal/react/RequestMetadata.kt
+++ b/android/src/main/java/com/authsignal/react/RequestMetadata.kt
@@ -1,0 +1,13 @@
+package com.authsignal.react
+
+import com.authsignal.AuthsignalRequestMetadata
+
+internal object RequestMetadata {
+  fun configure() {
+    AuthsignalRequestMetadata.setWrapperSDK(
+      sdk = "react-native",
+      version = BuildConfig.VERSION_NAME,
+      userAgentToken = "AuthsignalReactNativeSDK",
+    )
+  }
+}

--- a/ios/AuthsignalEmailModule.swift
+++ b/ios/AuthsignalEmailModule.swift
@@ -17,6 +17,7 @@ class AuthsignalEmailModule: NSObject {
     resolve: @escaping RCTPromiseResolveBlock,
     reject: @escaping RCTPromiseRejectBlock
   ) -> Void {
+    RequestMetadata.configure()
     self.authsignal = AuthsignalEmail(tenantID: tenantID as String, baseURL: baseURL as String)
     
     resolve(nil)

--- a/ios/AuthsignalInAppModule.swift
+++ b/ios/AuthsignalInAppModule.swift
@@ -17,6 +17,7 @@ class AuthsignalInAppModule: NSObject {
     resolve: @escaping RCTPromiseResolveBlock,
     reject: @escaping RCTPromiseRejectBlock
   ) -> Void {
+    RequestMetadata.configure()
     self.authsignal = AuthsignalInApp(tenantID: tenantID as String, baseURL: baseURL as String)
     
     resolve(nil)

--- a/ios/AuthsignalPasskeyModule.swift
+++ b/ios/AuthsignalPasskeyModule.swift
@@ -18,6 +18,7 @@ class AuthsignalPasskeyModule: NSObject {
     resolve: @escaping RCTPromiseResolveBlock,
     reject: @escaping RCTPromiseRejectBlock
   ) -> Void {
+    RequestMetadata.configure()
     self.authsignal = AuthsignalPasskey(tenantID: tenantID as String, baseURL: baseURL as String, deviceID: deviceID as String?)
     
     resolve(nil)

--- a/ios/AuthsignalPushModule.swift
+++ b/ios/AuthsignalPushModule.swift
@@ -17,6 +17,7 @@ class AuthsignalPushModule: NSObject {
     resolve: @escaping RCTPromiseResolveBlock,
     reject: @escaping RCTPromiseRejectBlock
   ) -> Void {
+    RequestMetadata.configure()
     self.authsignal = AuthsignalPush(tenantID: tenantID as String, baseURL: baseURL as String)
     
     resolve(nil)

--- a/ios/AuthsignalQRModule.swift
+++ b/ios/AuthsignalQRModule.swift
@@ -17,6 +17,7 @@ class AuthsignalQRCodeModule: NSObject {
     resolve: @escaping RCTPromiseResolveBlock,
     reject: @escaping RCTPromiseRejectBlock
   ) -> Void {
+    RequestMetadata.configure()
     self.authsignal = AuthsignalQRCode(tenantID: tenantID as String, baseURL: baseURL as String)
     
     resolve(nil)

--- a/ios/AuthsignalSMSModule.swift
+++ b/ios/AuthsignalSMSModule.swift
@@ -17,6 +17,7 @@ class AuthsignalSMSModule: NSObject {
     resolve: @escaping RCTPromiseResolveBlock,
     reject: @escaping RCTPromiseRejectBlock
   ) -> Void {
+    RequestMetadata.configure()
     self.authsignal = AuthsignalSMS(tenantID: tenantID as String, baseURL: baseURL as String)
     
     resolve(nil)

--- a/ios/AuthsignalTOTPModule.swift
+++ b/ios/AuthsignalTOTPModule.swift
@@ -17,6 +17,7 @@ class AuthsignalTOTPModule: NSObject {
     resolve: @escaping RCTPromiseResolveBlock,
     reject: @escaping RCTPromiseRejectBlock
   ) -> Void {
+    RequestMetadata.configure()
     self.authsignal = AuthsignalTOTP(tenantID: tenantID as String, baseURL: baseURL as String)
     
     resolve(nil)

--- a/ios/AuthsignalWhatsappModule.swift
+++ b/ios/AuthsignalWhatsappModule.swift
@@ -17,6 +17,7 @@ class AuthsignalWhatsappModule: NSObject {
     resolve: @escaping RCTPromiseResolveBlock,
     reject: @escaping RCTPromiseRejectBlock
   ) -> Void {
+    RequestMetadata.configure()
     self.authsignal = AuthsignalWhatsApp(tenantID: tenantID as String, baseURL: baseURL as String)
     
     resolve(nil)

--- a/ios/RequestMetadata.swift
+++ b/ios/RequestMetadata.swift
@@ -1,0 +1,14 @@
+import Authsignal
+import Foundation
+
+private let authsignalReactNativeVersion = "2.12.1"
+
+enum RequestMetadata {
+  static func configure() {
+    AuthsignalRequestMetadata.setWrapperSDK(
+      "react-native",
+      version: authsignalReactNativeVersion,
+      userAgentToken: "AuthsignalReactNativeSDK"
+    )
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-authsignal",
-  "version": "2.9.0",
+  "version": "2.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-authsignal",
-      "version": "2.9.0",
+      "version": "2.12.1",
       "license": "MIT",
       "devDependencies": {
         "@authsignal/browser": "^1.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-authsignal",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "The official Authsignal React Native library.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-authsignal.podspec
+++ b/react-native-authsignal.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.private_header_files = "ios/**/*.h"
 
   s.dependency "React-Core"
-  s.dependency 'Authsignal', '2.8.0'
+  s.dependency 'Authsignal', '~> 2.8.1'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
### New Features
Sets React Native wrapper metadata during native initialization so RN traffic is identified as React Native instead of plain Android/iOS.


### Checklist
- [x] Version bumped