### PR TITLE
[codex] Add passkey sync support to React Native SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Then link the native iOS dependencies:
 npx pod-install ios
 ```
 
+For Android apps, use compile SDK 35 and Android Gradle Plugin 8.6.0 or newer.
+
 ## Initialization
 
 Initialize the Authsignal client in your code:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 
   implementation "androidx.browser:browser:1.2.0"
 
-  implementation("com.authsignal:authsignal-android:3.10.0")
+  implementation("com.authsignal:authsignal-android:3.11.0")
 
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,6 +1,6 @@
 Authsignal_kotlinVersion=2.1.0
 Authsignal_minSdkVersion=24
 Authsignal_targetSdkVersion=34
-Authsignal_compileSdkVersion=34
+Authsignal_compileSdkVersion=35
 Authsignal_ndkversion=26.1.10909125
 android.useAndroidX=true

--- a/android/src/main/java/com/authsignal/react/AuthsignalPasskeyModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalPasskeyModule.kt
@@ -32,9 +32,9 @@ class AuthsignalPasskeyModule(private val reactContext: ReactApplicationContext)
   }
 
   @ReactMethod
-  override fun signUp(token: String?, username: String?, displayName: String?, ignorePasskeyAlreadyExistsError: Boolean, promise: Promise) {
+  override fun signUp(token: String?, username: String?, displayName: String?, ignorePasskeyAlreadyExistsError: Boolean, syncCredentials: Boolean, promise: Promise) {
     launch(promise) {
-      val response = it.signUp(token, username, displayName, false, ignorePasskeyAlreadyExistsError)
+      val response = it.signUp(token, username, displayName, false, ignorePasskeyAlreadyExistsError, syncCredentials)
 
       if (response.error != null) {
         val errorCode = response.errorCode ?: defaultError
@@ -58,10 +58,11 @@ class AuthsignalPasskeyModule(private val reactContext: ReactApplicationContext)
     token: String?,
     _autofill: Boolean,
     preferImmediatelyAvailableCredentials: Boolean,
+    syncCredentials: Boolean,
     promise: Promise
   ) {
     launch(promise) {
-      val response = it.signIn(action, token, preferImmediatelyAvailableCredentials)
+      val response = it.signIn(action, token, preferImmediatelyAvailableCredentials, syncCredentials)
 
       if (response.error != null) {
         val errorCode = response.errorCode ?: defaultError
@@ -83,7 +84,6 @@ class AuthsignalPasskeyModule(private val reactContext: ReactApplicationContext)
 
   @ReactMethod
   override fun cancel() {
-    // No-op on Android; cancel is only applicable for iOS autofill
   }
 
   @ReactMethod

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Authsignal (2.4.0-alpha.1)
+  - Authsignal (2.10.0)
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
   - EXConstants (17.1.8):
@@ -1401,8 +1401,8 @@ PODS:
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
-  - react-native-authsignal (2.7.0-alpha.1):
-    - Authsignal (= 2.4.0-alpha.1)
+  - react-native-authsignal (2.14.0):
+    - Authsignal (~> 2.10.0)
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2139,7 +2139,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Authsignal: 2a8eb981ba1e0298b2e89d54029ef08170305a16
+  Authsignal: 650b2226ebdfd5dad665929d42782f3d8ca5d927
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   EXConstants: d3d551cb154718f5161c4247304e96aa59f6cca7
@@ -2188,7 +2188,7 @@ SPEC CHECKSUMS:
   React-logger: 1426d04b594a2e68b0ac2add21d45422d06397a3
   React-Mapbuffer: 70a29536f84ddffca4a91097651d2b8f194f7c67
   React-microtasksnativemodule: ff05e894231c44c21135d1d23a82b87656d98eeb
-  react-native-authsignal: 6476028e79dde2593767b958ece21475862673b2
+  react-native-authsignal: 307cf77a221650f787b897dd3f0348a6c8005401
   react-native-safe-area-context: 562163222d999b79a51577eda2ea8ad2c32b4d06
   React-NativeModulesApple: d94850b316446b0c39a82eb278d6efaa1a634055
   React-oscompat: 56b4766e96b06843a3af49a6763ef40992e720aa

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -26,9 +26,9 @@ export function HomeScreen() {
   const [email, setEmail] = useState('');
   const [phone, setPhone] = useState('+1234567890');
 
-  const [lastPushChallengeId, setLastPushChallengeId] = useState<
-    string | null
-  >(null);
+  const [lastPushChallengeId, setLastPushChallengeId] = useState<string | null>(
+    null
+  );
 
   const [emailCode, setEmailCode] = useState('');
   const [smsCode, setSmsCode] = useState('');

--- a/ios/AuthsignalPasskeyModule.m
+++ b/ios/AuthsignalPasskeyModule.m
@@ -13,6 +13,7 @@ RCT_EXTERN_METHOD(signUp:(NSString)token
                   withUsername:(NSString)username
                   withDisplayName:(NSString)displayName
                   withIgnorePasskeyAlreadyExistsError:(BOOL)ignorePasskeyAlreadyExistsError
+                  withSyncCredentials:(BOOL)syncCredentials
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
@@ -20,6 +21,7 @@ RCT_EXTERN_METHOD(signIn:(NSString)action
                   withToken:(NSString)token
                   withAutofill:(BOOL)autofill
                   withPreferImmediatelyAvailableCredentials:(BOOL)preferImmediatelyAvailableCredentials
+                  withSyncCredentials:(BOOL)syncCredentials
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 

--- a/ios/AuthsignalPasskeyModule.swift
+++ b/ios/AuthsignalPasskeyModule.swift
@@ -29,6 +29,7 @@ class AuthsignalPasskeyModule: NSObject {
     withUsername username: NSString?,
     withDisplayName displayName: NSString?,
     withIgnorePasskeyAlreadyExistsError ignorePasskeyAlreadyExistsError: Bool,
+    withSyncCredentials syncCredentials: Bool,
     resolve: @escaping RCTPromiseResolveBlock,
     reject: @escaping RCTPromiseRejectBlock
   ) -> Void {
@@ -36,17 +37,18 @@ class AuthsignalPasskeyModule: NSObject {
       resolve(nil)
       return
     }
-    
+
     let tokenStr = token as String?
     let usernameStr = username as String?
     let displayNameStr = displayName as String?
-    
+
     Task.init {
       let response = await authsignal!.signUp(
         token: tokenStr,
         username: usernameStr,
         displayName: displayNameStr,
-        ignorePasskeyAlreadyExistsError: ignorePasskeyAlreadyExistsError
+        ignorePasskeyAlreadyExistsError: ignorePasskeyAlreadyExistsError,
+        syncCredentials: syncCredentials
       )
 
       if (response.error != nil) {
@@ -66,6 +68,7 @@ class AuthsignalPasskeyModule: NSObject {
     withToken token: NSString?,
     withAutofill autofill: Bool,
     withPreferImmediatelyAvailableCredentials preferImmediatelyAvailableCredentials: Bool,
+    withSyncCredentials syncCredentials: Bool,
     resolve: @escaping RCTPromiseResolveBlock,
     reject: @escaping RCTPromiseRejectBlock
   ) -> Void {
@@ -73,16 +76,17 @@ class AuthsignalPasskeyModule: NSObject {
       resolve(nil)
       return
     }
-    
+
     let actionStr = action as String?
     let tokenStr = token as String?
-    
+
     Task.init {
       let response = await authsignal!.signIn(
         token: tokenStr,
         action: actionStr,
         autofill: autofill,
-        preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
+        preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials,
+        syncCredentials: syncCredentials
       )
       
       if (response.error != nil) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "react-native-authsignal",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-authsignal",
-      "version": "2.13.0",
+      "version": "2.14.0",
       "license": "MIT",
       "devDependencies": {
-        "@authsignal/browser": "^1.13.1",
+        "@authsignal/browser": "^1.17.0",
         "@react-native-community/eslint-config": "^3.0.2",
         "@types/react": "~17.0.21",
         "@types/react-native": "0.68.0",
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@authsignal/browser": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@authsignal/browser/-/browser-1.13.1.tgz",
-      "integrity": "sha512-skB5Rj8kBtgNyWsaMTz/pdhCzgQWVse7fDwZ199RxNP/ZvB0mcGBoAOt2zBO1VWvjHztph5Hg1HwrjRReGLQpQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@authsignal/browser/-/browser-1.17.0.tgz",
+      "integrity": "sha512-64CxGaG79tE+UtdeJ9dfJQmaCEgwbqD+LMUyDfqR4wCTZlUl4/8ug8Xq1hPDWVDSr5tRRPn1I0UawFUFXxNLTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-authsignal",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "description": "The official Authsignal React Native library.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -53,7 +53,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
-    "@authsignal/browser": "^1.13.1",
+    "@authsignal/browser": "^1.17.0",
     "@react-native-community/eslint-config": "^3.0.2",
     "@types/react": "~17.0.21",
     "@types/react-native": "0.68.0",

--- a/react-native-authsignal.podspec
+++ b/react-native-authsignal.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.private_header_files = "ios/**/*.h"
 
   s.dependency "React-Core"
-  s.dependency 'Authsignal', '~> 2.9.0'
+  s.dependency 'Authsignal', '~> 2.10.0'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/src/NativeAuthsignalPasskeyModule.ts
+++ b/src/NativeAuthsignalPasskeyModule.ts
@@ -10,13 +10,15 @@ export interface Spec extends TurboModule {
     token: string | null,
     withUsername: string | null,
     withDisplayName: string | null,
-    withIgnorePasskeyAlreadyExistsError: boolean
+    withIgnorePasskeyAlreadyExistsError: boolean,
+    withSyncCredentials: boolean
   ): Promise<Object | null>;
   signIn(
     action: string | null,
     withToken: string | null,
     withAutofill: boolean,
-    withPreferImmediatelyAvailableCredentials: boolean
+    withPreferImmediatelyAvailableCredentials: boolean,
+    withSyncCredentials: boolean
   ): Promise<Object | null>;
   shouldPromptToCreatePasskey(username: string | null): Promise<boolean>;
   isAvailableOnDevice(): Promise<boolean>;

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -58,7 +58,7 @@ export class AuthsignalPasskey {
     username,
     displayName,
     ignorePasskeyAlreadyExistsError = false,
-    syncCredentials = true,
+    syncCredentials = false,
   }: PasskeySignUpInput = {}): Promise<AuthsignalResponse<SignUpResponse>> {
     await this.ensureModuleIsInitialized();
 
@@ -86,7 +86,7 @@ export class AuthsignalPasskey {
     token,
     autofill = false,
     preferImmediatelyAvailableCredentials = true,
-    syncCredentials = true,
+    syncCredentials = false,
   }: PasskeySignInInput = {}): Promise<AuthsignalResponse<SignInResponse>> {
     await this.ensureModuleIsInitialized();
 

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -22,6 +22,7 @@ interface PasskeySignUpInput {
   username?: string;
   displayName?: string;
   ignorePasskeyAlreadyExistsError?: boolean;
+  syncCredentials?: boolean;
 }
 
 interface PasskeySignInInput {
@@ -29,6 +30,7 @@ interface PasskeySignInInput {
   token?: string;
   autofill?: boolean;
   preferImmediatelyAvailableCredentials?: boolean;
+  syncCredentials?: boolean;
 }
 
 const AuthsignalPasskeyModule = getNativeModule<AuthsignalPasskeyModuleSpec>(
@@ -56,6 +58,7 @@ export class AuthsignalPasskey {
     username,
     displayName,
     ignorePasskeyAlreadyExistsError = false,
+    syncCredentials = true,
   }: PasskeySignUpInput = {}): Promise<AuthsignalResponse<SignUpResponse>> {
     await this.ensureModuleIsInitialized();
 
@@ -64,7 +67,8 @@ export class AuthsignalPasskey {
         token ?? null,
         username ?? null,
         displayName ?? null,
-        ignorePasskeyAlreadyExistsError
+        ignorePasskeyAlreadyExistsError,
+        syncCredentials
       )) as SignUpResponse;
 
       return { data };
@@ -82,6 +86,7 @@ export class AuthsignalPasskey {
     token,
     autofill = false,
     preferImmediatelyAvailableCredentials = true,
+    syncCredentials = true,
   }: PasskeySignInInput = {}): Promise<AuthsignalResponse<SignInResponse>> {
     await this.ensureModuleIsInitialized();
 
@@ -98,7 +103,8 @@ export class AuthsignalPasskey {
         action ?? null,
         token ?? null,
         autofill,
-        preferImmediatelyAvailableCredentials
+        preferImmediatelyAvailableCredentials,
+        syncCredentials
       )) as SignInResponse;
 
       this.autofillRequestPending = false;

--- a/src/passkey.web.ts
+++ b/src/passkey.web.ts
@@ -46,7 +46,7 @@ export class AuthsignalPasskey {
     username,
     displayName,
     ignorePasskeyAlreadyExistsError = false,
-    syncCredentials = true,
+    syncCredentials = false,
   }: PasskeySignUpInput = {}): Promise<AuthsignalResponse<SignUpResponse>> {
     try {
       const client = this.getClient();
@@ -80,7 +80,7 @@ export class AuthsignalPasskey {
     action,
     token,
     autofill = false,
-    syncCredentials = true,
+    syncCredentials = false,
   }: PasskeySignInInput = {}): Promise<AuthsignalResponse<SignInResponse>> {
     try {
       const client = this.getClient();

--- a/src/passkey.web.ts
+++ b/src/passkey.web.ts
@@ -18,12 +18,14 @@ interface PasskeySignUpInput {
   username?: string;
   displayName?: string;
   ignorePasskeyAlreadyExistsError?: boolean;
+  syncCredentials?: boolean;
 }
 
 interface PasskeySignInInput {
   action?: string;
   token?: string;
   autofill?: boolean;
+  syncCredentials?: boolean;
 }
 
 export class AuthsignalPasskey {
@@ -44,6 +46,7 @@ export class AuthsignalPasskey {
     username,
     displayName,
     ignorePasskeyAlreadyExistsError = false,
+    syncCredentials = true,
   }: PasskeySignUpInput = {}): Promise<AuthsignalResponse<SignUpResponse>> {
     try {
       const client = this.getClient();
@@ -51,6 +54,7 @@ export class AuthsignalPasskey {
         token,
         username,
         displayName,
+        syncCredentials,
       });
 
       if (result.errorCode) {
@@ -76,6 +80,7 @@ export class AuthsignalPasskey {
     action,
     token,
     autofill = false,
+    syncCredentials = true,
   }: PasskeySignInInput = {}): Promise<AuthsignalResponse<SignInResponse>> {
     try {
       const client = this.getClient();
@@ -83,6 +88,7 @@ export class AuthsignalPasskey {
         action,
         token,
         autofill,
+        syncCredentials,
       });
 
       if (result.errorCode) {
@@ -110,8 +116,7 @@ export class AuthsignalPasskey {
   }
 
   cancel() {
-    // On web, passkey operations are managed by the browser
-    // and cannot be programmatically cancelled
+    return;
   }
 
   isSupported(): boolean {


### PR DESCRIPTION
### New Features
1. Added opt-in passkey credential sync with `syncCredentials` defaulting to `false`.

### Checklist
- [x] Version bumped