### PR TITLE
Add push credential update (AUT-3560)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 
   implementation "androidx.browser:browser:1.2.0"
 
-  implementation("com.authsignal:authsignal-android:3.11.0")
+  implementation("com.authsignal:authsignal-android:3.12.0")
 
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
 }

--- a/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
@@ -156,6 +156,29 @@ class AuthsignalPushModule(private val reactContext: ReactApplicationContext) :
     }
   }
 
+  @ReactMethod
+  override fun updateCredential(pushToken: String, promise: Promise) {
+    launch(promise) {
+      val response = it.updateCredential(pushToken)
+
+      if (response.error != null) {
+        val errorCode = response.errorCode ?: defaultError
+
+        promise.reject(errorCode, response.error)
+      } else if (response.data != null) {
+        val credential = response.data
+        val map = Arguments.createMap()
+        map.putString("credentialId", credential!!.credentialId)
+        map.putString("createdAt", credential.createdAt)
+        map.putString("userId", credential.userId)
+        map.putString("lastAuthenticatedAt", credential.lastAuthenticatedAt)
+        promise.resolve(map)
+      } else {
+        promise.resolve(null)
+      }
+    }
+  }
+
   private fun launch(promise: Promise, fn: suspend (client: AuthsignalPush) -> Unit) {
     coroutineScope.launch {
       authsignal?.let {

--- a/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
@@ -161,17 +161,18 @@ class AuthsignalPushModule(private val reactContext: ReactApplicationContext) :
     launch(promise) {
       val response = it.updateCredential(pushToken)
 
+      val credential = response.data
+
       if (response.error != null) {
         val errorCode = response.errorCode ?: defaultError
 
         promise.reject(errorCode, response.error)
-      } else if (response.data != null) {
-        val credential = response.data
+      } else if (credential != null) {
         val map = Arguments.createMap()
-        map.putString("credentialId", credential!!.credentialId)
-        map.putString("createdAt", credential.createdAt)
+        map.putString("userAuthenticatorId", credential.userAuthenticatorId)
         map.putString("userId", credential.userId)
-        map.putString("lastAuthenticatedAt", credential.lastAuthenticatedAt)
+        map.putString("lastVerifiedAt", credential.lastVerifiedAt)
+        map.putString("pushToken", credential.pushToken)
         promise.resolve(map)
       } else {
         promise.resolve(null)

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -726,7 +726,7 @@ export function HomeScreen() {
 
       if (response.data) {
         addOutput('Push credential updated');
-        addOutput(`  Credential ID: ${response.data.credentialId}`);
+        addOutput(`  Credential ID: ${response.data.userAuthenticatorId}`);
       } else {
         addOutput(`Failed to update push credential: ${response.error}`);
       }

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -712,6 +712,29 @@ export function HomeScreen() {
     }
   };
 
+  const updatePushCredential = async () => {
+    const authsignal = authsignalRef.current;
+    if (!authsignal) return;
+
+    try {
+      // Simulated new FCM/APNs token - in production this comes from the OS push service.
+      const newPushToken = `test-push-token-${Date.now()}`;
+
+      addOutput('Updating push credential...');
+      const response = await authsignal.push.updateCredential(newPushToken);
+
+      if (response.data) {
+        addOutput('Push credential updated');
+        addOutput(`  Credential ID: ${response.data.credentialId}`);
+        addOutput(`  New token: ${newPushToken}`);
+      } else {
+        addOutput(`Failed to update push credential: ${response.error}`);
+      }
+    } catch (e) {
+      addOutput(`Error: ${e}`);
+    }
+  };
+
   const ActionButton = ({
     title,
     onPress,
@@ -830,6 +853,11 @@ export function HomeScreen() {
           title="Reject"
           onPress={() => updatePushChallenge(false)}
           disabled={!isInitialized || !lastPushChallengeId}
+        />
+        <ActionButton
+          title="Update Credential"
+          onPress={updatePushCredential}
+          disabled={!isInitialized}
         />
         <ActionButton
           title="Remove"

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -717,16 +717,16 @@ export function HomeScreen() {
     if (!authsignal) return;
 
     try {
-      // Simulated new FCM/APNs token - in production this comes from the OS push service.
-      const newPushToken = `test-push-token-${Date.now()}`;
+      // Pass the device's current FCM (Android) / APNs (iOS) push token, e.g. from
+      // messaging().getToken(). This example uses a placeholder to demonstrate the call.
+      const pushToken = `example-push-token-${Date.now()}`;
 
       addOutput('Updating push credential...');
-      const response = await authsignal.push.updateCredential(newPushToken);
+      const response = await authsignal.push.updateCredential(pushToken);
 
       if (response.data) {
         addOutput('Push credential updated');
         addOutput(`  Credential ID: ${response.data.credentialId}`);
-        addOutput(`  New token: ${newPushToken}`);
       } else {
         addOutput(`Failed to update push credential: ${response.error}`);
       }

--- a/ios/AuthsignalPushModule.m
+++ b/ios/AuthsignalPushModule.m
@@ -31,4 +31,8 @@ RCT_EXTERN_METHOD(updateChallenge:(NSString)challengeId
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(updateCredential:(NSString)pushToken
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
 @end

--- a/ios/AuthsignalPushModule.swift
+++ b/ios/AuthsignalPushModule.swift
@@ -198,10 +198,10 @@ class AuthsignalPushModule: NSObject {
         reject(response.errorCode ?? "unexpected_error", error, nil)
       } else if let data = response.data {
         let credential: [String: String?] = [
-          "credentialId": data.credentialId,
-          "createdAt": data.createdAt,
+          "userAuthenticatorId": data.userAuthenticatorId,
           "userId": data.userId,
-          "lastAuthenticatedAt": data.lastAuthenticatedAt,
+          "lastVerifiedAt": data.lastVerifiedAt,
+          "pushToken": data.pushToken,
         ]
 
         resolve(credential)

--- a/ios/AuthsignalPushModule.swift
+++ b/ios/AuthsignalPushModule.swift
@@ -82,19 +82,21 @@ class AuthsignalPushModule: NSObject {
       
       if let error = response.error {
         reject(response.errorCode ?? "unexpected_error", error, nil)
-      } else {
+      } else if let data = response.data {
          let credential: [String: String?] = [
-          "credentialId": response.data!.credentialId,
-          "createdAt": response.data!.createdAt,
-          "userId": response.data!.userId,
-          "lastAuthenticatedAt": response.data!.lastAuthenticatedAt,
+          "credentialId": data.credentialId,
+          "createdAt": data.createdAt,
+          "userId": data.userId,
+          "lastAuthenticatedAt": data.lastAuthenticatedAt,
         ]
-        
+
         resolve(credential)
+      } else {
+        resolve(nil)
       }
     }
   }
-  
+
   @objc func removeCredential(
     _ resolve: @escaping RCTPromiseResolveBlock,
     reject: @escaping RCTPromiseRejectBlock
@@ -179,6 +181,36 @@ class AuthsignalPushModule: NSObject {
     }
   }
   
+  @objc func updateCredential(
+    _ pushToken: NSString,
+    resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) -> Void {
+    guard let authsignal = authsignal else {
+      resolve(nil)
+      return
+    }
+
+    Task.init {
+      let response = await authsignal.updateCredential(pushToken: pushToken as String)
+
+      if let error = response.error {
+        reject(response.errorCode ?? "unexpected_error", error, nil)
+      } else if let data = response.data {
+        let credential: [String: String?] = [
+          "credentialId": data.credentialId,
+          "createdAt": data.createdAt,
+          "userId": data.userId,
+          "lastAuthenticatedAt": data.lastAuthenticatedAt,
+        ]
+
+        resolve(credential)
+      } else {
+        resolve(nil)
+      }
+    }
+  }
+
   func getKeychainAccess(value: String?) -> KeychainAccess {
     switch value {
     case "afterFirstUnlock":

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-authsignal",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "description": "The official Authsignal React Native library.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-authsignal.podspec
+++ b/react-native-authsignal.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.private_header_files = "ios/**/*.h"
 
   s.dependency "React-Core"
-  s.dependency 'Authsignal', '~> 2.10.0'
+  s.dependency 'Authsignal', '~> 2.11.0'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/src/NativeAuthsignalPushModule.ts
+++ b/src/NativeAuthsignalPushModule.ts
@@ -17,6 +17,7 @@ export interface Spec extends TurboModule {
     withApproval: boolean,
     withVerificationCode: string | null
   ): Promise<boolean>;
+  updateCredential(pushToken: string): Promise<Object | null>;
 }
 
 export default TurboModuleRegistry.get<Spec>('AuthsignalPushModule');

--- a/src/push.ts
+++ b/src/push.ts
@@ -9,6 +9,7 @@ import type {
   AppCredential,
   AuthsignalResponse,
   UpdateChallengeInput,
+  UpdatedAppCredential,
 } from './types';
 
 interface ConstructorArgs {
@@ -141,13 +142,13 @@ export class AuthsignalPush {
 
   async updateCredential(
     pushToken: string
-  ): Promise<AuthsignalResponse<AppCredential>> {
+  ): Promise<AuthsignalResponse<UpdatedAppCredential>> {
     await this.ensureModuleIsInitialized();
 
     try {
       const data = (await AuthsignalPushModule.updateCredential(
         pushToken
-      )) as AppCredential;
+      )) as UpdatedAppCredential;
 
       return { data };
     } catch (ex) {

--- a/src/push.ts
+++ b/src/push.ts
@@ -139,6 +139,26 @@ export class AuthsignalPush {
     }
   }
 
+  async updateCredential(
+    pushToken: string
+  ): Promise<AuthsignalResponse<AppCredential>> {
+    await this.ensureModuleIsInitialized();
+
+    try {
+      const data = (await AuthsignalPushModule.updateCredential(
+        pushToken
+      )) as AppCredential;
+
+      return { data };
+    } catch (ex) {
+      if (this.enableLogging) {
+        console.log(ex);
+      }
+
+      return handleErrorCodes(ex);
+    }
+  }
+
   private async ensureModuleIsInitialized() {
     if (this.initialized) {
       return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,13 @@ export interface AppCredential {
   lastAuthenticatedAt?: string;
 }
 
+export interface UpdatedAppCredential {
+  userAuthenticatorId: string;
+  userId: string;
+  lastVerifiedAt: string;
+  pushToken: string;
+}
+
 export interface ClaimChallengeInput {
   challengeId: string;
 }


### PR DESCRIPTION
Adds `push.updateCredential(pushToken)` so an enrolled device can refresh its push (FCM/APNs) token.

The device proves possession of its credential by signing a server-issued single-use nonce; the backend verifies the signature against the public key on file before applying the update. No user session or track call required. This bridges the native method added in the iOS and Android SDKs.

Changes:
- TS `push.updateCredential` + TurboModule spec entry.
- iOS bridge (`.swift`/`.m`) and Android bridge (`.kt`).
- Native dep bumps: iOS `Authsignal ~> 2.11.0`, Android `authsignal-android:3.12.0`.
- Example app: an "Update Credential" button to exercise the flow.
- Version bumped 2.14.0 → 2.15.0.

Requires the native SDK releases (authsignal-ios#83, authsignal-android#94) and the backend endpoints from authsignal-serverless#2645 (`POST /push/sign` + `PATCH /push`). All must be released together.