### PR TITLE
Add Ktor 3 Android SDK support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 
   implementation "androidx.browser:browser:1.2.0"
 
-  implementation("com.authsignal:authsignal-android:3.11.0")
+  implementation("com.authsignal:authsignal-android:4.0.0")
 
-  implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+  implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1")
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -41,7 +41,7 @@ newArchEnabled=true
 # If set to false, you will be using JSC instead.
 hermesEnabled=true
 
-# Override Kotlin version for authsignal-android compatibility (compiled with Kotlin 2.1.0)
+# Override Kotlin version for Android dependency compatibility.
 kotlinVersion=2.1.20
 
 # Enable GIF support in React Native images (~200 B increase)

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1401,7 +1401,7 @@ PODS:
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
-  - react-native-authsignal (2.14.0):
+  - react-native-authsignal (3.0.0):
     - Authsignal (~> 2.10.0)
     - DoubleConversion
     - glog
@@ -2188,7 +2188,7 @@ SPEC CHECKSUMS:
   React-logger: 1426d04b594a2e68b0ac2add21d45422d06397a3
   React-Mapbuffer: 70a29536f84ddffca4a91097651d2b8f194f7c67
   React-microtasksnativemodule: ff05e894231c44c21135d1d23a82b87656d98eeb
-  react-native-authsignal: 307cf77a221650f787b897dd3f0348a6c8005401
+  react-native-authsignal: eb926c0fb7fb2f138e1ac8a39c564ec38ea91faf
   react-native-safe-area-context: 562163222d999b79a51577eda2ea8ad2c32b4d06
   React-NativeModulesApple: d94850b316446b0c39a82eb278d6efaa1a634055
   React-oscompat: 56b4766e96b06843a3af49a6763ef40992e720aa

--- a/ios/RequestMetadata.swift
+++ b/ios/RequestMetadata.swift
@@ -1,7 +1,7 @@
 import Authsignal
 import Foundation
 
-private let authsignalReactNativeVersion = "2.12.1"
+private let authsignalReactNativeVersion = "3.0.0"
 
 enum RequestMetadata {
   static func configure() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-authsignal",
-  "version": "2.14.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-authsignal",
-      "version": "2.14.0",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "@authsignal/browser": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-authsignal",
-  "version": "2.14.0",
+  "version": "3.0.0",
   "description": "The official Authsignal React Native library.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
### Breaking Changes
- Bumped `react-native-authsignal` from `2.14.0` to `3.0.0` to pick up the Android SDK major version update.

### New Features
- Updated the Android dependency to `com.authsignal:authsignal-android:4.0.0`.
- Updated Android `kotlinx-serialization-json` to `1.8.1`.

### Bug Fixes
- Avoids runtime crashes in React Native apps where another dependency resolves Ktor to 3.x.

### Checklist
- [x] Version bumped
- [ ] Documentation updated
