### PR TITLE
feat(push): resetExpiry flag + optional pushToken (AUT-3576)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 
   implementation "androidx.browser:browser:1.2.0"
 
-  implementation("com.authsignal:authsignal-android:4.1.0")
+  implementation("com.authsignal:authsignal-android:4.2.0")
 
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1")
 }

--- a/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
@@ -44,7 +44,6 @@ class AuthsignalPushModule(private val reactContext: ReactApplicationContext) :
         map.putString("userId", credential.userId)
         map.putString("lastAuthenticatedAt", credential.lastAuthenticatedAt)
         credential.expiresAt?.let { map.putDouble("expiresAt", it.toDouble()) }
-        map.putBoolean("isExpired", credential.isExpired)
         promise.resolve(map)
       } else {
         promise.resolve(null)
@@ -81,7 +80,6 @@ class AuthsignalPushModule(private val reactContext: ReactApplicationContext) :
         map.putString("userId", credential.userId)
         map.putString("lastAuthenticatedAt", credential.lastAuthenticatedAt)
         credential.expiresAt?.let { map.putDouble("expiresAt", it.toDouble()) }
-        map.putBoolean("isExpired", credential.isExpired)
         promise.resolve(map)
       }
     }

--- a/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
@@ -157,9 +157,9 @@ class AuthsignalPushModule(private val reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  override fun updateCredential(pushToken: String?, withExtend: Boolean, promise: Promise) {
+  override fun updateCredential(pushToken: String?, withResetExpiry: Boolean, promise: Promise) {
     launch(promise) {
-      val response = it.updateCredential(pushToken, extend = withExtend)
+      val response = it.updateCredential(pushToken, resetExpiry = withResetExpiry)
 
       val credential = response.data
 

--- a/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
@@ -43,7 +43,7 @@ class AuthsignalPushModule(private val reactContext: ReactApplicationContext) :
         map.putString("createdAt", credential.createdAt)
         map.putString("userId", credential.userId)
         map.putString("lastAuthenticatedAt", credential.lastAuthenticatedAt)
-        map.putString("expiresAt", credential.expiresAt)
+        credential.expiresAt?.let { map.putDouble("expiresAt", it.toDouble()) }
         map.putBoolean("isExpired", credential.isExpired)
         promise.resolve(map)
       } else {
@@ -80,7 +80,7 @@ class AuthsignalPushModule(private val reactContext: ReactApplicationContext) :
         map.putString("createdAt", credential.createdAt)
         map.putString("userId", credential.userId)
         map.putString("lastAuthenticatedAt", credential.lastAuthenticatedAt)
-        map.putString("expiresAt", credential.expiresAt)
+        credential.expiresAt?.let { map.putDouble("expiresAt", it.toDouble()) }
         map.putBoolean("isExpired", credential.isExpired)
         promise.resolve(map)
       }
@@ -177,7 +177,7 @@ class AuthsignalPushModule(private val reactContext: ReactApplicationContext) :
         map.putString("userId", credential.userId)
         map.putString("lastVerifiedAt", credential.lastVerifiedAt)
         map.putString("pushToken", credential.pushToken)
-        map.putString("expiresAt", credential.expiresAt)
+        credential.expiresAt?.let { map.putDouble("expiresAt", it.toDouble()) }
         promise.resolve(map)
       } else {
         promise.resolve(null)

--- a/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
@@ -157,9 +157,9 @@ class AuthsignalPushModule(private val reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  override fun updateCredential(pushToken: String, promise: Promise) {
+  override fun updateCredential(pushToken: String?, withExtend: Boolean, promise: Promise) {
     launch(promise) {
-      val response = it.updateCredential(pushToken)
+      val response = it.updateCredential(pushToken, extend = withExtend)
 
       val credential = response.data
 

--- a/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
@@ -43,6 +43,8 @@ class AuthsignalPushModule(private val reactContext: ReactApplicationContext) :
         map.putString("createdAt", credential.createdAt)
         map.putString("userId", credential.userId)
         map.putString("lastAuthenticatedAt", credential.lastAuthenticatedAt)
+        map.putString("expiresAt", credential.expiresAt)
+        map.putBoolean("isExpired", credential.isExpired)
         promise.resolve(map)
       } else {
         promise.resolve(null)
@@ -78,6 +80,8 @@ class AuthsignalPushModule(private val reactContext: ReactApplicationContext) :
         map.putString("createdAt", credential.createdAt)
         map.putString("userId", credential.userId)
         map.putString("lastAuthenticatedAt", credential.lastAuthenticatedAt)
+        map.putString("expiresAt", credential.expiresAt)
+        map.putBoolean("isExpired", credential.isExpired)
         promise.resolve(map)
       }
     }
@@ -173,6 +177,7 @@ class AuthsignalPushModule(private val reactContext: ReactApplicationContext) :
         map.putString("userId", credential.userId)
         map.putString("lastVerifiedAt", credential.lastVerifiedAt)
         map.putString("pushToken", credential.pushToken)
+        map.putString("expiresAt", credential.expiresAt)
         promise.resolve(map)
       } else {
         promise.resolve(null)

--- a/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
@@ -159,9 +159,9 @@ class AuthsignalPushModule(private val reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  override fun updateCredential(pushToken: String?, withResetExpiry: Boolean, promise: Promise) {
+  override fun updateCredential(pushToken: String?, resetExpiry: Boolean, promise: Promise) {
     launch(promise) {
-      val response = it.updateCredential(pushToken, resetExpiry = withResetExpiry)
+      val response = it.updateCredential(pushToken, resetExpiry)
 
       val credential = response.data
 

--- a/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalPushModule.kt
@@ -43,7 +43,7 @@ class AuthsignalPushModule(private val reactContext: ReactApplicationContext) :
         map.putString("createdAt", credential.createdAt)
         map.putString("userId", credential.userId)
         map.putString("lastAuthenticatedAt", credential.lastAuthenticatedAt)
-        credential.expiresAt?.let { map.putDouble("expiresAt", it.toDouble()) }
+        map.putString("expiresAt", credential.expiresAt)
         promise.resolve(map)
       } else {
         promise.resolve(null)
@@ -79,7 +79,7 @@ class AuthsignalPushModule(private val reactContext: ReactApplicationContext) :
         map.putString("createdAt", credential.createdAt)
         map.putString("userId", credential.userId)
         map.putString("lastAuthenticatedAt", credential.lastAuthenticatedAt)
-        credential.expiresAt?.let { map.putDouble("expiresAt", it.toDouble()) }
+        map.putString("expiresAt", credential.expiresAt)
         promise.resolve(map)
       }
     }
@@ -175,7 +175,7 @@ class AuthsignalPushModule(private val reactContext: ReactApplicationContext) :
         map.putString("userId", credential.userId)
         map.putString("lastVerifiedAt", credential.lastVerifiedAt)
         map.putString("pushToken", credential.pushToken)
-        credential.expiresAt?.let { map.putDouble("expiresAt", it.toDouble()) }
+        map.putString("expiresAt", credential.expiresAt)
         promise.resolve(map)
       } else {
         promise.resolve(null)

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -741,21 +741,23 @@ export function HomeScreen() {
     }
   };
 
-  const extendPushCredential = async () => {
+  const resetPushCredentialExpiry = async () => {
     const authsignal = authsignalRef.current;
     if (!authsignal) return;
 
     try {
       // Keep-alive: reset the credential lease without necessarily rotating the
       // push token. `pushToken` is optional — omit it to preserve the stored token.
-      addOutput('Extending push credential lease...');
-      const response = await authsignal.push.updateCredential({ extend: true });
+      addOutput('Resetting push credential expiry...');
+      const response = await authsignal.push.updateCredential({
+        resetExpiry: true,
+      });
 
       if (response.data) {
-        addOutput('Push credential lease extended');
+        addOutput('Push credential expiry reset');
         addOutput(`  Credential ID: ${response.data.userAuthenticatorId}`);
       } else {
-        addOutput(`Failed to extend push credential: ${response.error}`);
+        addOutput(`Failed to reset push credential expiry: ${response.error}`);
       }
     } catch (e) {
       addOutput(`Error: ${e}`);
@@ -887,8 +889,8 @@ export function HomeScreen() {
           disabled={!isInitialized}
         />
         <ActionButton
-          title="Extend Credential"
-          onPress={extendPushCredential}
+          title="Reset Expiry"
+          onPress={resetPushCredentialExpiry}
           disabled={!isInitialized}
         />
         <ActionButton

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -607,11 +607,7 @@ export function HomeScreen() {
       addOutput(`  Credential ID: ${response.data.credentialId}`);
       addOutput(`  User ID: ${response.data.userId}`);
       if (response.data.expiresAt) {
-        addOutput(
-          `  Expires At: ${new Date(
-            response.data.expiresAt * 1000
-          ).toISOString()}`
-        );
+        addOutput(`  Expires At: ${response.data.expiresAt}`);
       }
     } catch (e) {
       addOutput(`Error: ${e}`);
@@ -786,11 +782,7 @@ export function HomeScreen() {
         addOutput('Push credential expiry reset');
         addOutput(`  Credential ID: ${response.data.userAuthenticatorId}`);
         if (response.data.expiresAt) {
-          addOutput(
-            `  New Expires At: ${new Date(
-              response.data.expiresAt * 1000
-            ).toISOString()}`
-          );
+          addOutput(`  New Expires At: ${response.data.expiresAt}`);
         }
       } else {
         addOutput(`Failed to reset push credential expiry: ${response.error}`);

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -607,7 +607,11 @@ export function HomeScreen() {
       addOutput(`  Credential ID: ${response.data.credentialId}`);
       addOutput(`  User ID: ${response.data.userId}`);
       if (response.data.expiresAt) {
-        addOutput(`  Expires At: ${response.data.expiresAt}`);
+        addOutput(
+          `  Expires At: ${new Date(
+            response.data.expiresAt * 1000
+          ).toISOString()}`
+        );
       }
       if (response.data.isExpired !== undefined) {
         addOutput(`  Is Expired: ${response.data.isExpired}`);
@@ -785,7 +789,11 @@ export function HomeScreen() {
         addOutput('Push credential expiry reset');
         addOutput(`  Credential ID: ${response.data.userAuthenticatorId}`);
         if (response.data.expiresAt) {
-          addOutput(`  New Expires At: ${response.data.expiresAt}`);
+          addOutput(
+            `  New Expires At: ${new Date(
+              response.data.expiresAt * 1000
+            ).toISOString()}`
+          );
         }
       } else {
         addOutput(`Failed to reset push credential expiry: ${response.error}`);

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -605,6 +605,12 @@ export function HomeScreen() {
       addOutput('Push credential found');
       addOutput(`  Credential ID: ${response.data.credentialId}`);
       addOutput(`  User ID: ${response.data.userId}`);
+      if (response.data.expiresAt) {
+        addOutput(`  Expires At: ${response.data.expiresAt}`);
+      }
+      if (response.data.isExpired !== undefined) {
+        addOutput(`  Is Expired: ${response.data.isExpired}`);
+      }
     } catch (e) {
       addOutput(`Error: ${e}`);
     }
@@ -722,13 +728,34 @@ export function HomeScreen() {
       const pushToken = `example-push-token-${Date.now()}`;
 
       addOutput('Updating push credential...');
-      const response = await authsignal.push.updateCredential(pushToken);
+      const response = await authsignal.push.updateCredential({ pushToken });
 
       if (response.data) {
         addOutput('Push credential updated');
         addOutput(`  Credential ID: ${response.data.userAuthenticatorId}`);
       } else {
         addOutput(`Failed to update push credential: ${response.error}`);
+      }
+    } catch (e) {
+      addOutput(`Error: ${e}`);
+    }
+  };
+
+  const extendPushCredential = async () => {
+    const authsignal = authsignalRef.current;
+    if (!authsignal) return;
+
+    try {
+      // Keep-alive: reset the credential lease without necessarily rotating the
+      // push token. `pushToken` is optional — omit it to preserve the stored token.
+      addOutput('Extending push credential lease...');
+      const response = await authsignal.push.updateCredential({ extend: true });
+
+      if (response.data) {
+        addOutput('Push credential lease extended');
+        addOutput(`  Credential ID: ${response.data.userAuthenticatorId}`);
+      } else {
+        addOutput(`Failed to extend push credential: ${response.error}`);
       }
     } catch (e) {
       addOutput(`Error: ${e}`);
@@ -857,6 +884,11 @@ export function HomeScreen() {
         <ActionButton
           title="Update Credential"
           onPress={updatePushCredential}
+          disabled={!isInitialized}
+        />
+        <ActionButton
+          title="Extend Credential"
+          onPress={extendPushCredential}
           disabled={!isInitialized}
         />
         <ActionButton

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -614,8 +614,6 @@ export function HomeScreen() {
     }
   };
 
-  // Copies the credential's public key (credentialId) to the clipboard for testing —
-  // e.g. pasting into Postman's publicKey variable so a local signer can sign for it.
   const copyPushPublicKey = async () => {
     const authsignal = authsignalRef.current;
     if (!authsignal) return;
@@ -771,8 +769,6 @@ export function HomeScreen() {
     if (!authsignal) return;
 
     try {
-      // Keep-alive: reset the credential lease without necessarily rotating the
-      // push token. `pushToken` is optional — omit it to preserve the stored token.
       addOutput('Resetting push credential expiry...');
       const response = await authsignal.push.updateCredential({
         resetExpiry: true,

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
+  Clipboard,
   Platform,
   ScrollView,
   StyleSheet,
@@ -616,6 +617,33 @@ export function HomeScreen() {
     }
   };
 
+  // Copies the credential's public key (credentialId) to the clipboard for testing —
+  // e.g. pasting into Postman's publicKey variable so a local signer can sign for it.
+  const copyPushPublicKey = async () => {
+    const authsignal = authsignalRef.current;
+    if (!authsignal) return;
+
+    try {
+      const response = await authsignal.push.getCredential();
+
+      if (!response.data) {
+        addOutput(
+          response.error
+            ? `Error: ${response.error}`
+            : 'No push credential on this device'
+        );
+        return;
+      }
+
+      const publicKey = response.data.credentialId;
+      Clipboard.setString(publicKey);
+      addOutput('Public key copied to clipboard');
+      addOutput(`  ${publicKey}`);
+    } catch (e) {
+      addOutput(`Error: ${e}`);
+    }
+  };
+
   const enrollPush = async () => {
     const authsignal = authsignalRef.current;
     if (!authsignal) return;
@@ -861,6 +889,11 @@ export function HomeScreen() {
         <ActionButton
           title="Get Credential"
           onPress={getPushCredential}
+          disabled={!isInitialized}
+        />
+        <ActionButton
+          title="Copy Public Key"
+          onPress={copyPushPublicKey}
           disabled={!isInitialized}
         />
         <ActionButton

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -613,9 +613,6 @@ export function HomeScreen() {
           ).toISOString()}`
         );
       }
-      if (response.data.isExpired !== undefined) {
-        addOutput(`  Is Expired: ${response.data.isExpired}`);
-      }
     } catch (e) {
       addOutput(`Error: ${e}`);
     }

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -784,6 +784,9 @@ export function HomeScreen() {
       if (response.data) {
         addOutput('Push credential expiry reset');
         addOutput(`  Credential ID: ${response.data.userAuthenticatorId}`);
+        if (response.data.expiresAt) {
+          addOutput(`  New Expires At: ${response.data.expiresAt}`);
+        }
       } else {
         addOutput(`Failed to reset push credential expiry: ${response.error}`);
       }

--- a/ios/AuthsignalPushModule.m
+++ b/ios/AuthsignalPushModule.m
@@ -32,6 +32,7 @@ RCT_EXTERN_METHOD(updateChallenge:(NSString)challengeId
                   reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(updateCredential:(NSString)pushToken
+                  withExtend:(BOOL)withExtend
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 

--- a/ios/AuthsignalPushModule.m
+++ b/ios/AuthsignalPushModule.m
@@ -32,7 +32,7 @@ RCT_EXTERN_METHOD(updateChallenge:(NSString)challengeId
                   reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(updateCredential:(NSString)pushToken
-                  withExtend:(BOOL)withExtend
+                  withResetExpiry:(BOOL)withResetExpiry
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 

--- a/ios/AuthsignalPushModule.swift
+++ b/ios/AuthsignalPushModule.swift
@@ -204,7 +204,7 @@ class AuthsignalPushModule: NSObject {
       if let error = response.error {
         reject(response.errorCode ?? "unexpected_error", error, nil)
       } else if let data = response.data {
-        let credential: [String: String?] = [
+        let credential: [String: Any?] = [
           "userAuthenticatorId": data.userAuthenticatorId,
           "userId": data.userId,
           "lastVerifiedAt": data.lastVerifiedAt,

--- a/ios/AuthsignalPushModule.swift
+++ b/ios/AuthsignalPushModule.swift
@@ -44,7 +44,6 @@ class AuthsignalPushModule: NSObject {
           "userId": data.userId,
           "lastAuthenticatedAt": data.lastAuthenticatedAt,
           "expiresAt": data.expiresAt,
-          "isExpired": data.isExpired,
         ]
 
         resolve(credential)
@@ -91,7 +90,6 @@ class AuthsignalPushModule: NSObject {
           "userId": data.userId,
           "lastAuthenticatedAt": data.lastAuthenticatedAt,
           "expiresAt": data.expiresAt,
-          "isExpired": data.isExpired,
         ]
 
         resolve(credential)

--- a/ios/AuthsignalPushModule.swift
+++ b/ios/AuthsignalPushModule.swift
@@ -38,13 +38,15 @@ class AuthsignalPushModule: NSObject {
       if let error = response.error {
         reject(response.errorCode ?? "unexpected_error", error, nil)
       } else if let data = response.data {
-        let credential: [String: String?] = [
+        let credential: [String: Any?] = [
           "credentialId": data.credentialId,
           "createdAt": data.createdAt,
           "userId": data.userId,
           "lastAuthenticatedAt": data.lastAuthenticatedAt,
+          "expiresAt": data.expiresAt,
+          "isExpired": data.isExpired,
         ]
-        
+
         resolve(credential)
       } else {
         resolve(nil)
@@ -83,11 +85,13 @@ class AuthsignalPushModule: NSObject {
       if let error = response.error {
         reject(response.errorCode ?? "unexpected_error", error, nil)
       } else if let data = response.data {
-         let credential: [String: String?] = [
+         let credential: [String: Any?] = [
           "credentialId": data.credentialId,
           "createdAt": data.createdAt,
           "userId": data.userId,
           "lastAuthenticatedAt": data.lastAuthenticatedAt,
+          "expiresAt": data.expiresAt,
+          "isExpired": data.isExpired,
         ]
 
         resolve(credential)
@@ -205,6 +209,7 @@ class AuthsignalPushModule: NSObject {
           "userId": data.userId,
           "lastVerifiedAt": data.lastVerifiedAt,
           "pushToken": data.pushToken,
+          "expiresAt": data.expiresAt,
         ]
 
         resolve(credential)

--- a/ios/AuthsignalPushModule.swift
+++ b/ios/AuthsignalPushModule.swift
@@ -183,7 +183,7 @@ class AuthsignalPushModule: NSObject {
   
   @objc func updateCredential(
     _ pushToken: NSString?,
-    withExtend extend: Bool,
+    withResetExpiry resetExpiry: Bool,
     resolve: @escaping RCTPromiseResolveBlock,
     reject: @escaping RCTPromiseRejectBlock
   ) -> Void {
@@ -195,7 +195,7 @@ class AuthsignalPushModule: NSObject {
     let pushTokenStr = pushToken as String?
 
     Task.init {
-      let response = await authsignal.updateCredential(pushToken: pushTokenStr, extend: extend)
+      let response = await authsignal.updateCredential(pushToken: pushTokenStr, resetExpiry: resetExpiry)
 
       if let error = response.error {
         reject(response.errorCode ?? "unexpected_error", error, nil)

--- a/ios/AuthsignalPushModule.swift
+++ b/ios/AuthsignalPushModule.swift
@@ -182,7 +182,8 @@ class AuthsignalPushModule: NSObject {
   }
   
   @objc func updateCredential(
-    _ pushToken: NSString,
+    _ pushToken: NSString?,
+    withExtend extend: Bool,
     resolve: @escaping RCTPromiseResolveBlock,
     reject: @escaping RCTPromiseRejectBlock
   ) -> Void {
@@ -191,8 +192,10 @@ class AuthsignalPushModule: NSObject {
       return
     }
 
+    let pushTokenStr = pushToken as String?
+
     Task.init {
-      let response = await authsignal.updateCredential(pushToken: pushToken as String)
+      let response = await authsignal.updateCredential(pushToken: pushTokenStr, extend: extend)
 
       if let error = response.error {
         reject(response.errorCode ?? "unexpected_error", error, nil)

--- a/ios/RequestMetadata.swift
+++ b/ios/RequestMetadata.swift
@@ -1,7 +1,7 @@
 import Authsignal
 import Foundation
 
-private let authsignalReactNativeVersion = "3.0.0"
+private let authsignalReactNativeVersion = "3.2.0"
 
 enum RequestMetadata {
   static func configure() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-authsignal",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "The official Authsignal React Native library.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-authsignal.podspec
+++ b/react-native-authsignal.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.private_header_files = "ios/**/*.h"
 
   s.dependency "React-Core"
-  s.dependency 'Authsignal', '~> 2.11.0'
+  s.dependency 'Authsignal', '~> 2.12.0'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/src/NativeAuthsignalPushModule.ts
+++ b/src/NativeAuthsignalPushModule.ts
@@ -19,7 +19,7 @@ export interface Spec extends TurboModule {
   ): Promise<boolean>;
   updateCredential(
     pushToken: string | null,
-    withExtend: boolean
+    withResetExpiry: boolean
   ): Promise<Object | null>;
 }
 

--- a/src/NativeAuthsignalPushModule.ts
+++ b/src/NativeAuthsignalPushModule.ts
@@ -17,7 +17,10 @@ export interface Spec extends TurboModule {
     withApproval: boolean,
     withVerificationCode: string | null
   ): Promise<boolean>;
-  updateCredential(pushToken: string): Promise<Object | null>;
+  updateCredential(
+    pushToken: string | null,
+    withExtend: boolean
+  ): Promise<Object | null>;
 }
 
 export default TurboModuleRegistry.get<Spec>('AuthsignalPushModule');

--- a/src/push.ts
+++ b/src/push.ts
@@ -147,15 +147,15 @@ export class AuthsignalPush {
     await this.ensureModuleIsInitialized();
 
     // Backward compatible: existing callers pass a `pushToken` string directly.
-    const { pushToken, extend = false } =
+    const { pushToken, resetExpiry = false } =
       typeof input === 'string'
-        ? { pushToken: input, extend: false }
+        ? { pushToken: input, resetExpiry: false }
         : input ?? {};
 
     try {
       const data = (await AuthsignalPushModule.updateCredential(
         pushToken ?? null,
-        extend
+        resetExpiry
       )) as UpdatedAppCredential;
 
       return { data };

--- a/src/push.ts
+++ b/src/push.ts
@@ -146,7 +146,6 @@ export class AuthsignalPush {
   ): Promise<AuthsignalResponse<UpdatedAppCredential>> {
     await this.ensureModuleIsInitialized();
 
-    // Backward compatible: existing callers pass a `pushToken` string directly.
     const { pushToken, resetExpiry = false } =
       typeof input === 'string'
         ? { pushToken: input, resetExpiry: false }

--- a/src/push.ts
+++ b/src/push.ts
@@ -9,6 +9,7 @@ import type {
   AppCredential,
   AuthsignalResponse,
   UpdateChallengeInput,
+  UpdateCredentialInput,
   UpdatedAppCredential,
 } from './types';
 
@@ -141,13 +142,20 @@ export class AuthsignalPush {
   }
 
   async updateCredential(
-    pushToken: string
+    input?: UpdateCredentialInput | string
   ): Promise<AuthsignalResponse<UpdatedAppCredential>> {
     await this.ensureModuleIsInitialized();
 
+    // Backward compatible: existing callers pass a `pushToken` string directly.
+    const { pushToken, extend = false } =
+      typeof input === 'string'
+        ? { pushToken: input, extend: false }
+        : input ?? {};
+
     try {
       const data = (await AuthsignalPushModule.updateCredential(
-        pushToken
+        pushToken ?? null,
+        extend
       )) as UpdatedAppCredential;
 
       return { data };

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,7 +89,7 @@ export interface UpdateCredentialInput {
    * When `true`, resets the credential lease (keep-alive). When omitted or
    * `false`, the call only updates the push token without resetting the lease.
    */
-  extend?: boolean;
+  resetExpiry?: boolean;
 }
 
 export interface UpdatedAppCredential {

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,13 +73,9 @@ export interface AppCredential {
   createdAt: string;
   userId: string;
   lastAuthenticatedAt?: string;
-  /** ISO timestamp at which the credential lease expires, if the credential has an expiry. */
-  expiresAt?: string;
-  /**
-   * True if the credential lease has lapsed, computed on-device from `expiresAt`.
-   * The server rejects expired credentials (getCredential errors rather than
-   * returning one), so this is only true for a credential held past its expiry.
-   */
+  /** Unix epoch seconds at which the credential lease expires, if the credential has an expiry. */
+  expiresAt?: number;
+  /** True if the credential lease has lapsed, computed on-device from `expiresAt`. */
   isExpired?: boolean;
 }
 
@@ -102,8 +98,8 @@ export interface UpdatedAppCredential {
   lastVerifiedAt: string;
   /** Echoes the request's push token; absent for keep-alive calls that omit it. */
   pushToken?: string;
-  /** ISO timestamp of the new credential lease, if the credential has an expiry. */
-  expiresAt?: string;
+  /** Unix epoch seconds of the new credential lease, if the credential has an expiry. */
+  expiresAt?: number;
 }
 
 export interface ClaimChallengeInput {

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,8 +75,6 @@ export interface AppCredential {
   lastAuthenticatedAt?: string;
   /** Unix epoch seconds at which the credential lease expires, if the credential has an expiry. */
   expiresAt?: number;
-  /** True if the credential lease has lapsed, computed on-device from `expiresAt`. */
-  isExpired?: boolean;
 }
 
 export interface UpdateCredentialInput {

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,23 @@ export interface AppCredential {
   createdAt: string;
   userId: string;
   lastAuthenticatedAt?: string;
+  /** ISO timestamp at which the credential lease expires, if the credential has an expiry. */
+  expiresAt?: string;
+  /** True if the credential lease has expired. */
+  isExpired?: boolean;
+}
+
+export interface UpdateCredentialInput {
+  /**
+   * The device's current push token (FCM/APNs). Optional — when omitted, the
+   * server preserves the stored token.
+   */
+  pushToken?: string;
+  /**
+   * When `true`, resets the credential lease (keep-alive). When omitted or
+   * `false`, the call only updates the push token without resetting the lease.
+   */
+  extend?: boolean;
 }
 
 export interface UpdatedAppCredential {

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,7 +75,11 @@ export interface AppCredential {
   lastAuthenticatedAt?: string;
   /** ISO timestamp at which the credential lease expires, if the credential has an expiry. */
   expiresAt?: string;
-  /** True if the credential lease has expired. */
+  /**
+   * True if the credential lease has lapsed, computed on-device from `expiresAt`.
+   * The server rejects expired credentials (getCredential errors rather than
+   * returning one), so this is only true for a credential held past its expiry.
+   */
   isExpired?: boolean;
 }
 
@@ -96,7 +100,10 @@ export interface UpdatedAppCredential {
   userAuthenticatorId: string;
   userId: string;
   lastVerifiedAt: string;
-  pushToken: string;
+  /** Echoes the request's push token; absent for keep-alive calls that omit it. */
+  pushToken?: string;
+  /** ISO timestamp of the new credential lease, if the credential has an expiry. */
+  expiresAt?: string;
 }
 
 export interface ClaimChallengeInput {

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,8 +73,8 @@ export interface AppCredential {
   createdAt: string;
   userId: string;
   lastAuthenticatedAt?: string;
-  /** Unix epoch seconds at which the credential lease expires, if the credential has an expiry. */
-  expiresAt?: number;
+  /** ISO timestamp at which the credential lease expires, if the credential has an expiry. */
+  expiresAt?: string;
 }
 
 export interface UpdateCredentialInput {
@@ -96,8 +96,8 @@ export interface UpdatedAppCredential {
   lastVerifiedAt: string;
   /** Echoes the request's push token; absent for keep-alive calls that omit it. */
   pushToken?: string;
-  /** Unix epoch seconds of the new credential lease, if the credential has an expiry. */
-  expiresAt?: number;
+  /** ISO timestamp of the new credential lease, if the credential has an expiry. */
+  expiresAt?: string;
 }
 
 export interface ClaimChallengeInput {

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,20 +73,11 @@ export interface AppCredential {
   createdAt: string;
   userId: string;
   lastAuthenticatedAt?: string;
-  /** ISO timestamp at which the credential lease expires, if the credential has an expiry. */
   expiresAt?: string;
 }
 
 export interface UpdateCredentialInput {
-  /**
-   * The device's current push token (FCM/APNs). Optional — when omitted, the
-   * server preserves the stored token.
-   */
   pushToken?: string;
-  /**
-   * When `true`, resets the credential lease (keep-alive). When omitted or
-   * `false`, the call only updates the push token without resetting the lease.
-   */
   resetExpiry?: boolean;
 }
 
@@ -94,9 +85,7 @@ export interface UpdatedAppCredential {
   userAuthenticatorId: string;
   userId: string;
   lastVerifiedAt: string;
-  /** Echoes the request's push token; absent for keep-alive calls that omit it. */
   pushToken?: string;
-  /** ISO timestamp of the new credential lease, if the credential has an expiry. */
   expiresAt?: string;
 }
 


### PR DESCRIPTION
## What's new

Adds support for push credential expiry and keep-alive.

- `updateCredential` now accepts an options object with an optional `pushToken` and a new `resetExpiry` flag:

  ```typescript
  // Rotate the push token (existing behaviour, unchanged)
  await authsignal.push.updateCredential({ pushToken });

  // Keep-alive: reset the credential's expiry lease without changing the token
  await authsignal.push.updateCredential({ resetExpiry: true });
  ```

- When `pushToken` is omitted, the server keeps the stored token.
- `getCredential` results now include `expiresAt` (ISO timestamp), so you can check when the credential's lease lapses and re-enroll in time. Expired credentials are rejected by the server and cannot be revived.
- The `updateCredential` response now includes the refreshed `expiresAt`.
- Example app: new Reset Expiry and Copy Public Key buttons, and credential output shows the expiry fields.

## Compatibility

Fully backward compatible: the existing `updateCredential('token')` string form still works.

Requires the native SDK releases that ship this feature: iOS 2.12.0 and Android 4.2.0 (pinned in this PR).

