### PR TITLE
fix(android): preserve launch result across browser lifecycle

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,32 +1,32 @@
-name-template: "v$RESOLVED_VERSION 🚀"
+name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 categories:
-  - title: "⚠️ Breaking Changes"
+  - title: "Breaking changes"
     labels:
       - "breaking"
       - "major"
-  - title: "🚀 Features"
+  - title: "New features"
     labels:
       - "feature"
       - "enhancement"
-  - title: "🐛 Bug Fixes"
+  - title: "Bug fixes"
     labels:
       - "fix"
       - "bugfix"
       - "bug"
-  - title: "🧰 Maintenance"
+  - title: "Maintenance"
     labels:
       - "chore"
       - "maintenance"
-  - title: "📚 Documentation"
+  - title: "Documentation"
     labels:
       - "documentation"
-  - title: "⬆️ Dependencies"
+  - title: "Dependencies"
     collapse-after: 5
     labels:
       - "dependencies"
 
-change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-template: "- $TITLE (#$NUMBER)"
 change-title-escapes: '\<*_&'
 version-resolver:
   major:
@@ -37,6 +37,7 @@ version-resolver:
     labels:
       - "minor"
       - "feature"
+      - "enhancement"
   patch:
     labels:
       - "patch"
@@ -65,11 +66,9 @@ autolabeler:
       - '/feature\/.+/'
   - label: "dependencies"
     files:
-      - "yarn.lock"
+      - "package-lock.json"
 
 template: |
-  ## Changes in Release v$RESOLVED_VERSION
-
   $CHANGES
 
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -64,7 +64,8 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
 
-  implementation "androidx.browser:browser:1.2.0"
+  implementation "androidx.activity:activity:1.9.0"
+  implementation "androidx.browser:browser:1.8.0"
 
   implementation("com.authsignal:authsignal-android:4.3.0")
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <!--suppress AndroidElementNotAllowed -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application>
@@ -14,8 +13,7 @@
         <activity
             android:name="com.authsignal.react.RedirectActivity"
             android:exported="true">
-            <intent-filter android:autoVerify="true"
-                tools:targetApi="m">
+            <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -26,6 +26,9 @@
 
     <queries>
         <intent>
+            <action android:name="android.support.customtabs.action.CustomTabsService" />
+        </intent>
+        <intent>
             <action android:name="android.intent.action.VIEW" />
             <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="https" />

--- a/android/src/main/java/com/authsignal/react/AuthenticationActivity.kt
+++ b/android/src/main/java/com/authsignal/react/AuthenticationActivity.kt
@@ -3,20 +3,29 @@ package com.authsignal.react
 import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import androidx.activity.ComponentActivity
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.browser.customtabs.CustomTabsIntent
+import androidx.browser.customtabs.CustomTabsService
 
 class AuthenticationActivity : ComponentActivity() {
   private var authenticationLaunched = false
   private var authenticationCompleted = false
+  private var authTabSupported = false
+  private var cancellationDeadlineMillis = 0L
   private val mainHandler = Handler(Looper.getMainLooper())
-  private val completeCancellation = Runnable { completeAuthentication(null) }
+  private val completeCancellation =
+    Runnable {
+      cancellationDeadlineMillis = 0L
+      completeAuthentication(null)
+    }
 
   private val browserLauncher =
     registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -29,8 +38,13 @@ class AuthenticationActivity : ComponentActivity() {
             completeAuthentication(redirectUri)
           }
         }
-        RESULT_CANCELED ->
-          mainHandler.postDelayed(completeCancellation, REDIRECT_GRACE_PERIOD_MILLIS)
+        RESULT_CANCELED -> {
+          if (authTabSupported) {
+            completeAuthentication(null)
+          } else {
+            scheduleCancellation()
+          }
+        }
         else ->
           completeWithError(
             "authentication_failed",
@@ -47,6 +61,10 @@ class AuthenticationActivity : ComponentActivity() {
         savedInstanceState.getBoolean(EXTRA_AUTHENTICATION_LAUNCHED, false)
       authenticationCompleted =
         savedInstanceState.getBoolean(EXTRA_AUTHENTICATION_COMPLETED, false)
+      authTabSupported =
+        savedInstanceState.getBoolean(EXTRA_AUTH_TAB_SUPPORTED, false)
+      cancellationDeadlineMillis =
+        savedInstanceState.getLong(EXTRA_CANCELLATION_DEADLINE_MILLIS, 0L)
     }
 
     intent.data?.let {
@@ -56,6 +74,11 @@ class AuthenticationActivity : ComponentActivity() {
 
     if (authenticationCompleted) {
       finish()
+      return
+    }
+
+    if (cancellationDeadlineMillis > 0L) {
+      scheduleCancellation(cancellationDeadlineMillis)
       return
     }
 
@@ -83,6 +106,13 @@ class AuthenticationActivity : ComponentActivity() {
     super.onSaveInstanceState(outState)
     outState.putBoolean(EXTRA_AUTHENTICATION_LAUNCHED, authenticationLaunched)
     outState.putBoolean(EXTRA_AUTHENTICATION_COMPLETED, authenticationCompleted)
+    outState.putBoolean(EXTRA_AUTH_TAB_SUPPORTED, authTabSupported)
+    outState.putLong(EXTRA_CANCELLATION_DEADLINE_MILLIS, cancellationDeadlineMillis)
+  }
+
+  override fun onDestroy() {
+    mainHandler.removeCallbacks(completeCancellation)
+    super.onDestroy()
   }
 
   override fun onNewIntent(intent: Intent) {
@@ -100,16 +130,50 @@ class AuthenticationActivity : ComponentActivity() {
         .putExtra(EXTRA_LAUNCH_AUTH_TAB, true)
         .putExtra(EXTRA_REDIRECT_SCHEME, CALLBACK_SCHEME)
 
+      authTabSupported = isAuthTabSupported(customTabsIntent.intent)
       browserLauncher.launch(customTabsIntent.intent)
     } catch (exception: ActivityNotFoundException) {
       completeWithError("browser_not_available", "No browser app is installed.")
     }
   }
 
+  private fun isAuthTabSupported(browserIntent: Intent): Boolean {
+    val browserPackage = browserIntent.resolveActivity(packageManager)?.packageName ?: return false
+    val serviceIntent =
+      Intent(CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION)
+        .setPackage(browserPackage)
+        .addCategory(CATEGORY_AUTH_TAB)
+
+    val service =
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        packageManager.resolveService(
+          serviceIntent,
+          PackageManager.ResolveInfoFlags.of(0)
+        )
+      } else {
+        @Suppress("DEPRECATION")
+        packageManager.resolveService(serviceIntent, 0)
+      }
+
+    return service != null
+  }
+
+  private fun scheduleCancellation(
+    deadlineMillis: Long = SystemClock.elapsedRealtime() + REDIRECT_GRACE_PERIOD_MILLIS
+  ) {
+    cancellationDeadlineMillis = deadlineMillis
+    mainHandler.removeCallbacks(completeCancellation)
+    mainHandler.postDelayed(
+      completeCancellation,
+      maxOf(0L, deadlineMillis - SystemClock.elapsedRealtime())
+    )
+  }
+
   private fun completeAuthentication(redirectUri: Uri?) {
     if (authenticationCompleted) return
 
     mainHandler.removeCallbacks(completeCancellation)
+    cancellationDeadlineMillis = 0L
     authenticationCompleted = true
     if (redirectUri == null) {
       setResult(RESULT_CANCELED)
@@ -122,6 +186,8 @@ class AuthenticationActivity : ComponentActivity() {
   private fun completeWithError(code: String, message: String) {
     if (authenticationCompleted) return
 
+    mainHandler.removeCallbacks(completeCancellation)
+    cancellationDeadlineMillis = 0L
     authenticationCompleted = true
     val result =
       Intent()
@@ -143,7 +209,12 @@ class AuthenticationActivity : ComponentActivity() {
       "com.authsignal.react.EXTRA_AUTHENTICATION_LAUNCHED"
     private const val EXTRA_AUTHENTICATION_COMPLETED =
       "com.authsignal.react.EXTRA_AUTHENTICATION_COMPLETED"
-    private const val REDIRECT_GRACE_PERIOD_MILLIS = 1_000L
+    private const val EXTRA_AUTH_TAB_SUPPORTED =
+      "com.authsignal.react.EXTRA_AUTH_TAB_SUPPORTED"
+    private const val EXTRA_CANCELLATION_DEADLINE_MILLIS =
+      "com.authsignal.react.EXTRA_CANCELLATION_DEADLINE_MILLIS"
+    private const val CATEGORY_AUTH_TAB = "androidx.browser.auth.category.AuthTab"
+    private const val REDIRECT_GRACE_PERIOD_MILLIS = 5_000L
 
     @JvmStatic
     fun authenticateUsingBrowser(activity: Activity, authorizeUri: Uri) {

--- a/android/src/main/java/com/authsignal/react/AuthenticationActivity.kt
+++ b/android/src/main/java/com/authsignal/react/AuthenticationActivity.kt
@@ -1,62 +1,154 @@
 package com.authsignal.react
 
 import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.browser.customtabs.CustomTabsIntent
 
-class AuthenticationActivity : Activity() {
-  private var intentLaunched = false
+class AuthenticationActivity : ComponentActivity() {
+  private var authenticationLaunched = false
+  private var authenticationCompleted = false
+  private val mainHandler = Handler(Looper.getMainLooper())
+  private val completeCancellation = Runnable { completeAuthentication(null) }
+
+  private val browserLauncher =
+    registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+      when (result.resultCode) {
+        RESULT_OK -> {
+          val redirectUri = result.data?.data
+          if (redirectUri == null) {
+            completeWithError("malformed_url", "The browser returned an empty redirect URL.")
+          } else {
+            completeAuthentication(redirectUri)
+          }
+        }
+        // A classic Custom Tab reports cancellation while handing a custom-scheme redirect back
+        // to the app. Give RedirectActivity.onNewIntent a brief chance to deliver that URI before
+        // treating the result as a user cancellation.
+        RESULT_CANCELED ->
+          mainHandler.postDelayed(completeCancellation, REDIRECT_GRACE_PERIOD_MILLIS)
+        else ->
+          completeWithError(
+            "authentication_failed",
+            "The browser could not complete authentication (result code ${result.resultCode})."
+          )
+      }
+    }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+
     if (savedInstanceState != null) {
-      intentLaunched = savedInstanceState.getBoolean(EXTRA_INTENT_LAUNCHED, false)
+      authenticationLaunched =
+        savedInstanceState.getBoolean(EXTRA_AUTHENTICATION_LAUNCHED, false)
+      authenticationCompleted =
+        savedInstanceState.getBoolean(EXTRA_AUTHENTICATION_COMPLETED, false)
     }
-  }
 
-  override fun onResume() {
-    super.onResume()
-    val authenticationIntent = intent
+    intent.data?.let {
+      completeAuthentication(it)
+      return
+    }
 
-    if (!intentLaunched && authenticationIntent.extras == null) {
+    if (authenticationCompleted) {
       finish()
       return
-    } else if (!intentLaunched) {
-      intentLaunched = true
-      launchAuthenticationIntent()
+    }
+
+    if (authenticationLaunched) {
       return
     }
 
-    val resultMissing = authenticationIntent.data == null
-    if (resultMissing) setResult(RESULT_CANCELED)
-    else setResult(RESULT_OK, authenticationIntent)
-    finish()
+    val authorizeUri =
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        intent.getParcelableExtra(EXTRA_AUTHORIZE_URI, Uri::class.java)
+      } else {
+        @Suppress("DEPRECATION")
+        intent.getParcelableExtra(EXTRA_AUTHORIZE_URI)
+      }
+    if (authorizeUri == null) {
+      completeWithError("invalid_url", "The authentication URL is missing.")
+      return
+    }
+
+    authenticationLaunched = true
+    launchAuthenticationIntent(authorizeUri)
   }
 
   override fun onSaveInstanceState(outState: Bundle) {
     super.onSaveInstanceState(outState)
-    outState.putBoolean(EXTRA_INTENT_LAUNCHED, intentLaunched)
+    outState.putBoolean(EXTRA_AUTHENTICATION_LAUNCHED, authenticationLaunched)
+    outState.putBoolean(EXTRA_AUTHENTICATION_COMPLETED, authenticationCompleted)
   }
 
-  override fun onNewIntent(intent: Intent?) {
+  override fun onNewIntent(intent: Intent) {
     super.onNewIntent(intent)
     setIntent(intent)
+    intent.data?.let(::completeAuthentication)
   }
 
-  private fun launchAuthenticationIntent() {
-    val extras = intent.extras
-    val authorizeUri = extras!!.getParcelable<Uri>(EXTRA_AUTHORIZE_URI)
-    val builder = CustomTabsIntent.Builder()
-    val customTabsIntent = builder.build()
-    customTabsIntent.launchUrl(this, authorizeUri!!)
+  private fun launchAuthenticationIntent(authorizeUri: Uri) {
+    try {
+      val customTabsIntent = CustomTabsIntent.Builder().build()
+
+      // Auth Tab is a public Custom Tabs intent protocol. Sending its stable extras directly keeps
+      // this SDK compatible with compileSdk 35 while browser 1.9+ requires compileSdk 36.
+      customTabsIntent.intent
+        .setData(authorizeUri)
+        .putExtra(EXTRA_LAUNCH_AUTH_TAB, true)
+        .putExtra(EXTRA_REDIRECT_SCHEME, CALLBACK_SCHEME)
+
+      browserLauncher.launch(customTabsIntent.intent)
+    } catch (exception: ActivityNotFoundException) {
+      completeWithError("browser_not_available", "No browser app is installed.")
+    }
+  }
+
+  private fun completeAuthentication(redirectUri: Uri?) {
+    if (authenticationCompleted) return
+
+    mainHandler.removeCallbacks(completeCancellation)
+    authenticationCompleted = true
+    if (redirectUri == null) {
+      setResult(RESULT_CANCELED)
+    } else {
+      setResult(RESULT_OK, Intent().setData(redirectUri))
+    }
+    finish()
+  }
+
+  private fun completeWithError(code: String, message: String) {
+    if (authenticationCompleted) return
+
+    authenticationCompleted = true
+    val result =
+      Intent()
+        .putExtra(EXTRA_ERROR_CODE, code)
+        .putExtra(EXTRA_ERROR_MESSAGE, message)
+    setResult(RESULT_CANCELED, result)
+    finish()
   }
 
   companion object {
     const val AUTHENTICATION_REQUEST: Int = 1000
+    const val CALLBACK_SCHEME: String = "authsignal"
     const val EXTRA_AUTHORIZE_URI: String = "com.authsignal.react.EXTRA_AUTHORIZE_URI"
-    private const val EXTRA_INTENT_LAUNCHED = "com.authsignal.react.EXTRA_INTENT_LAUNCHED"
+    const val EXTRA_ERROR_CODE: String = "com.authsignal.react.EXTRA_ERROR_CODE"
+    const val EXTRA_ERROR_MESSAGE: String = "com.authsignal.react.EXTRA_ERROR_MESSAGE"
+    private const val EXTRA_LAUNCH_AUTH_TAB = "androidx.browser.auth.extra.LAUNCH_AUTH_TAB"
+    private const val EXTRA_REDIRECT_SCHEME = "androidx.browser.auth.extra.REDIRECT_SCHEME"
+    private const val EXTRA_AUTHENTICATION_LAUNCHED =
+      "com.authsignal.react.EXTRA_AUTHENTICATION_LAUNCHED"
+    private const val EXTRA_AUTHENTICATION_COMPLETED =
+      "com.authsignal.react.EXTRA_AUTHENTICATION_COMPLETED"
+    private const val REDIRECT_GRACE_PERIOD_MILLIS = 1_000L
 
     @JvmStatic
     fun authenticateUsingBrowser(activity: Activity, authorizeUri: Uri) {

--- a/android/src/main/java/com/authsignal/react/AuthenticationActivity.kt
+++ b/android/src/main/java/com/authsignal/react/AuthenticationActivity.kt
@@ -29,9 +29,6 @@ class AuthenticationActivity : ComponentActivity() {
             completeAuthentication(redirectUri)
           }
         }
-        // A classic Custom Tab reports cancellation while handing a custom-scheme redirect back
-        // to the app. Give RedirectActivity.onNewIntent a brief chance to deliver that URI before
-        // treating the result as a user cancellation.
         RESULT_CANCELED ->
           mainHandler.postDelayed(completeCancellation, REDIRECT_GRACE_PERIOD_MILLIS)
         else ->
@@ -98,8 +95,6 @@ class AuthenticationActivity : ComponentActivity() {
     try {
       val customTabsIntent = CustomTabsIntent.Builder().build()
 
-      // Auth Tab is a public Custom Tabs intent protocol. Sending its stable extras directly keeps
-      // this SDK compatible with compileSdk 35 while browser 1.9+ requires compileSdk 36.
       customTabsIntent.intent
         .setData(authorizeUri)
         .putExtra(EXTRA_LAUNCH_AUTH_TAB, true)

--- a/android/src/main/java/com/authsignal/react/AuthsignalModule.kt
+++ b/android/src/main/java/com/authsignal/react/AuthsignalModule.kt
@@ -6,6 +6,10 @@ import android.content.Intent
 import android.net.Uri
 import com.authsignal.DeviceCache
 import com.authsignal.TokenCache.Companion.shared
+import com.authsignal.react.AuthenticationActivity.Companion.AUTHENTICATION_REQUEST
+import com.authsignal.react.AuthenticationActivity.Companion.CALLBACK_SCHEME
+import com.authsignal.react.AuthenticationActivity.Companion.EXTRA_ERROR_CODE
+import com.authsignal.react.AuthenticationActivity.Companion.EXTRA_ERROR_MESSAGE
 import com.authsignal.react.AuthenticationActivity.Companion.authenticateUsingBrowser
 import com.facebook.react.bridge.ActivityEventListener
 import com.facebook.react.bridge.Promise
@@ -16,7 +20,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import java.net.URLDecoder
 
 @ReactModule(name = AuthsignalModule.NAME)
 class AuthsignalModule(private val reactContext: ReactApplicationContext) :
@@ -38,6 +41,14 @@ class AuthsignalModule(private val reactContext: ReactApplicationContext) :
 
   @ReactMethod
   override fun launch(url: String?, promise: Promise) {
+    if (launchPromise != null) {
+      promise.reject(
+        "launch_in_progress",
+        "Another Authsignal browser flow is already in progress."
+      )
+      return
+    }
+
     if (url == null) {
       promise.reject("invalid_url", "Launch URL must not be null.")
       return
@@ -66,37 +77,36 @@ class AuthsignalModule(private val reactContext: ReactApplicationContext) :
     resultCode: Int,
     data: Intent?
   ) {
-    val pendingPromise = this@AuthsignalModule.launchPromise ?: return
+    if (requestCode != AUTHENTICATION_REQUEST) return
 
-    val hasResult =
-      resultCode == Activity.RESULT_OK && requestCode == AuthenticationActivity.AUTHENTICATION_REQUEST && data!!.data != null
+    val pendingPromise = launchPromise ?: return
+    launchPromise = null
 
-    if (hasResult) {
-      try {
-        val redirectUrl = data!!.data.toString()
-        val query = redirectUrl.split("[?]".toRegex()).dropLastWhile { it.isEmpty() }
-          .toTypedArray()[1]
-        val pairs = query.split("&".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-        var token: String? = null
-        for (pair in pairs) {
-          val index = pair.indexOf("=")
-          val name = URLDecoder.decode(pair.substring(0, index), "UTF-8")
-          val value = URLDecoder.decode(pair.substring(index + 1), "UTF-8")
-          if (name == "token") {
-            token = value
-
-            shared.token = value
-          }
-        }
-        pendingPromise.resolve(token)
-      } catch (ex: Exception) {
-        pendingPromise.reject("malformed_url", "Malformed redirect url")
-      }
-    } else {
-      pendingPromise.resolve(null)
+    val errorCode = data?.getStringExtra(EXTRA_ERROR_CODE)
+    if (errorCode != null) {
+      pendingPromise.reject(
+        errorCode,
+        data.getStringExtra(EXTRA_ERROR_MESSAGE) ?: "Authentication failed."
+      )
+      return
     }
 
-    this@AuthsignalModule.launchPromise = null
+    if (resultCode == Activity.RESULT_CANCELED) {
+      pendingPromise.resolve(null)
+      return
+    }
+
+    val redirectUri = data?.data
+    if (resultCode != Activity.RESULT_OK || redirectUri == null) {
+      pendingPromise.reject("malformed_url", "Malformed redirect URL.")
+      return
+    }
+
+    val token = redirectUri.getQueryParameter("token")
+    if (token != null) {
+      shared.token = token
+    }
+    pendingPromise.resolve(token)
   }
 
   @ReactMethod
@@ -129,7 +139,6 @@ class AuthsignalModule(private val reactContext: ReactApplicationContext) :
 
   companion object {
     const val NAME = "AuthsignalModule"
-    private const val CALLBACK_SCHEME = "authsignal"
     private const val NATIVE_SCHEME_QUERY_PARAM = "nativeScheme"
   }
 }

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -30,7 +30,7 @@
       }
     },
     "..": {
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "MIT",
       "devDependencies": {
         "@authsignal/browser": "^1.17.0",

--- a/ios/RequestMetadata.swift
+++ b/ios/RequestMetadata.swift
@@ -1,7 +1,7 @@
 import Authsignal
 import Foundation
 
-private let authsignalReactNativeVersion = "3.3.0"
+private let authsignalReactNativeVersion = "3.3.1"
 
 enum RequestMetadata {
   static func configure() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-authsignal",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-authsignal",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "MIT",
       "devDependencies": {
         "@authsignal/browser": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-authsignal",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "The official Authsignal React Native library.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
### Breaking Changes

None.

### New Features

None.

### Bug Fixes

- Prevent `Authsignal.launch()` from resolving `null` when the host activity resumes while the authentication browser is still open or minimized.
- Preserve successful callbacks when legacy Custom Tabs report cancellation immediately before delivering the `authsignal://` redirect.
- Reject concurrent launch attempts and ignore unrelated activity results to prevent promise mix-ups.
- Prefer Android Auth Tabs while retaining a compatible Custom Tabs fallback for older browsers.
- Align generated release notes with the shared SDK format and correctly detect `package-lock.json` dependency changes.

### Checklist

- [x] Version bumped
- [ ] Documentation updated
